### PR TITLE
Classic - Add Frost Shock, Viper Sting, Crippling Poison

### DIFF
--- a/Classic.lua
+++ b/Classic.lua
@@ -154,7 +154,7 @@ addon.Spells = {
 
     [8178] = { type = IMMUNITY }, -- Grounding Totem Effect
     [16188] = { type = BUFF_DEFENSIVE }, -- Nature's Swiftness
-    [12548] = { type = CROWD_CONTROL }, -- Frost Shock
+    [12548] = { type = ROOT }, -- Frost Shock
 
     -- Paladin
 
@@ -295,7 +295,7 @@ addon.Spells = {
         [11285] = { parent = 1776 },
         [11286] = { parent = 1776 },
     [14278] = { type = BUFF_DEFENSIVE }, -- Ghostly Strike
-    [3409] = { type = CROWD_CONTROL }, -- Crippling Poison
+    [3409] = { type = ROOT }, -- Crippling Poison
         [11201] = { parent = 3409 },
 
     -- Warrior

--- a/Classic.lua
+++ b/Classic.lua
@@ -154,6 +154,7 @@ addon.Spells = {
 
     [8178] = { type = IMMUNITY }, -- Grounding Totem Effect
     [16188] = { type = BUFF_DEFENSIVE }, -- Nature's Swiftness
+    [12548] = { type = CROWD_CONTROL }, -- Frost Shock
 
     -- Paladin
 
@@ -196,6 +197,9 @@ addon.Spells = {
     [19185] = { type = ROOT }, -- Entrapment
     [19503] = { type = CROWD_CONTROL }, -- Scatter Shot
     [25999] = { type = ROOT }, -- Boar Charge
+    [3034] = { type = CROWD_CONTROL }, -- Viper Sting
+        [14279] = { parent = 3034 },
+        [14280] = { parent = 3034 },
 
     -- Druid
 
@@ -291,6 +295,8 @@ addon.Spells = {
         [11285] = { parent = 1776 },
         [11286] = { parent = 1776 },
     [14278] = { type = BUFF_DEFENSIVE }, -- Ghostly Strike
+    [3409] = { type = CROWD_CONTROL }, -- Crippling Poison
+        [11201] = { parent = 3409 },
 
     -- Warrior
 

--- a/Classic.lua
+++ b/Classic.lua
@@ -306,6 +306,9 @@ addon.Spells = {
     [871] = { type = BUFF_DEFENSIVE }, -- Shield Wall
     [12328] = { type = BUFF_OFFENSIVE }, -- Death Wish
     [23694] = { type = ROOT }, -- Improved Hamstring
+    [1715] = { type = ROOT }, -- Hamstring
+        [7372] = { parent = 1715 },
+        [7373] = { parent = 1715 },
     [18499] = { type = BUFF_OFFENSIVE}, -- Berserker Rage
     [20253] = { type = CROWD_CONTROL }, -- Intercept Stun
         [20614] = { parent = 20253 },


### PR DESCRIPTION
Love your addon.
I wanted to add a few spells that should be highlighted as there are dispellable.

Viper Sting doesn't really belong to any existing category. But I think we call it a "crowd control" as it makes casters/healers useless if not dispelled quickly.

Frost Shock, Crippling Poison, Hamstring are snares, not really roots. Could be nice to add a category if you are interested in