### PR TITLE
Add Spell Viper Sting

### DIFF
--- a/Classic.lua
+++ b/Classic.lua
@@ -196,6 +196,9 @@ addon.Spells = {
     [19185] = { type = ROOT }, -- Entrapment
     [19503] = { type = CROWD_CONTROL }, -- Scatter Shot
     [25999] = { type = ROOT }, -- Boar Charge
+    [3034] = { type = CROWD_CONTROL }, -- Viper Sting
+        [14279] = { parent = 3034 },
+        [14280] = { parent = 3034 },
 
     -- Druid
 


### PR DESCRIPTION
I wanted to add this very annoying spell that should be "big" as it is dispellable.

Viper Sting doesn't really belong to any existing category. But I think we call it a "crowd control" as it makes casters/healers useless if not dispelled quickly.