### PR TITLE
Adding MCP haste buff

### DIFF
--- a/Classic.lua
+++ b/Classic.lua
@@ -79,6 +79,7 @@ addon.Spells = {
     [9774] = { type = BUFF_OFFENSIVE }, -- Spider Belt & Ornate Mithril Boots
     [18798] = { type = CROWD_CONTROL }, -- Freezing Band
     [22734] = { type = BUFF_OTHER }, -- Drink
+    [13494] = { type = BUFF_OFFENSIVE }, -- Manual Crowd Pummeler Haste buff
 
     -- Interrupts
     [15752] = { type = INTERRUPT, duration = 10 }, -- Linken's Boomerang Disarm


### PR DESCRIPTION
Tiny PR to add [the haste buff granted from Manual Crowd Pummeler](https://classic.wowhead.com/spell=13494/haste) to the list of classic spells.

This item is used regularly by feral druids as their big dps cooldown so I believe it's fit for purpose here