### PR TITLE
#115 Add Nightfall to Other Buffs

### DIFF
--- a/Classic.lua
+++ b/Classic.lua
@@ -37,6 +37,7 @@ addon.PriorityDebuffs = {
     19284, -- Hex of Weakness
     19285, -- Hex of Weakness
     23230, -- Blood Fury Debuff
+    23605, -- Nightfall, Spell Vulnerability
 }
 
 addon.Spells = {
@@ -82,6 +83,7 @@ addon.Spells = {
     [9774] = { type = BUFF_OFFENSIVE }, -- Spider Belt & Ornate Mithril Boots
     [18798] = { type = CROWD_CONTROL }, -- Freezing Band
     [22734] = { type = BUFF_OTHER }, -- Drink
+    [23605] = { type = BUFF_OTHER }, -- Nightfall, Spell Vulnerability
     [13494] = { type = BUFF_OFFENSIVE }, -- Manual Crowd Pummeler Haste buff
 
     -- Interrupts


### PR DESCRIPTION
Add [Spell Vulnerability](https://classic.wowhead.com/spell=23605/spell-vulnerability) to Other Buffs category.

Resolves #115