### PR TITLE
Absolute Zero Death Knight Legendary

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -111,7 +111,8 @@ addon.Spells = {
     [212552] = { type = BUFF_DEFENSIVE }, -- Wraith Walk
     [219809] = { type = BUFF_DEFENSIVE }, -- Tombstone
     [223929] = { type = BUFF_OTHER }, -- Necrotic Wound
-
+	[334693] = { type = CROWD_CONTROL }, -- Absolute Zero
+    
     -- Demon Hunter
 
     [179057] = { type = CROWD_CONTROL }, -- Chaos Nova


### PR DESCRIPTION
The Absolute Zero stun is missing from BigDebuffs.