### PR TITLE
Fix for false icons sticking to nameplates

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1790,15 +1790,7 @@ function BigDebuffs:UNIT_AURA(unit)
 end
 
 function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)
-    if not self.db.profile.nameplates.enabled
-		or not unit:find("nameplate")
-		or (not UnitCanAttack("player", unit) and not self.db.profile.nameplates.friendly)
-		or (UnitCanAttack("player", unit) and not self.db.profile.nameplates.enemy)
-		or (not UnitIsPlayer(unit) and not self.db.profile.nameplates.npc)
-		or (UnitIsUnit("player", unit))
-    then
-        return
-    end
+    if not self.db.profile.nameplates.enabled then return end
 
 	self:AttachNameplate(unit)
 
@@ -1903,6 +1895,17 @@ function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)
         frame.interrupt = interrupt
         frame.current = icon
     else
+        frame:Hide()
+        frame.current = nil
+    end
+    
+    --Hide/Disable auras which shouldn't be shown. Seems to fix false icons from appearing and getting stuck.
+    if frame.current ~= nil and (not unit:find("nameplate")
+        or (not UnitCanAttack("player", unit) and not self.db.profile.nameplates.friendly)
+        or (UnitCanAttack("player", unit) and not self.db.profile.nameplates.enemy)
+        or (not UnitIsPlayer(unit) and not self.db.profile.nameplates.npc)
+        or (UnitIsUnit("player", unit)))
+    then 
         frame:Hide()
         frame.current = nil
     end


### PR DESCRIPTION
Some people experience auras unexpectedly appearing and then remaining stuck on nameplates (see #236) and the personal resource display (see #234). It seems like sometimes the nameplates (particularly those that are supposed to be disabled) can occasionally inherit the displayed icon from another nameplate, and will then never expire. 

**_I don't know what is actually causing the problem_**, but discovered that moving the initial checks in 
`function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)` to the end of that block and hiding/disabling those frames, seems to prevent the issue from showing up. I don't fully understand exactly how everything in this addon works yet, but I guess that worst-case scenario there will now be a little more processor work, particularly for people who have some nameplate auras (i.e. npc) disabled.

So maybe you have a better solution, knowing that this at least _appears_ to fix it.