### PR TITLE
feat(unitframes): add offset options

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -59,6 +59,8 @@ local defaults = {
                 anchor = "auto",
                 anchorPoint = "auto",
                 relativePoint = "auto",
+                x = 0,
+                y = 0,
                 matchFrameHeight = true,
                 size = 50,
             },
@@ -67,6 +69,8 @@ local defaults = {
                 anchor = "auto",
                 anchorPoint = "auto",
                 relativePoint = "auto",
+                x = 0,
+                y = 0,
                 matchFrameHeight = true,
                 size = 50,
             },
@@ -75,6 +79,8 @@ local defaults = {
                 anchor = "auto",
                 anchorPoint = "auto",
                 relativePoint = "auto",
+                x = 0,
+                y = 0,
                 matchFrameHeight = true,
                 size = 50,
             },
@@ -83,6 +89,8 @@ local defaults = {
                 anchor = "auto",
                 anchorPoint = "auto",
                 relativePoint = "auto",
+                x = 0,
+                y = 0,
                 matchFrameHeight = true,
                 size = 50,
             },
@@ -192,6 +200,8 @@ else
         anchor = "auto",
         anchorPoint = "auto",
         relativePoint = "auto",
+        x = 0,
+        y = 0,
         matchFrameHeight = true,
         size = 50,
     }
@@ -201,6 +211,8 @@ else
         anchor = "auto",
         anchorPoint = "auto",
         relativePoint = "auto",
+        x = 0,
+        y = 0,
         matchFrameHeight = true,
         size = 50,
     }
@@ -577,6 +589,8 @@ function BigDebuffs:OnInitialize()
                 anchor = "auto",
                 anchorPoint = "auto",
                 relativePoint = "auto",
+                x = 0,
+                y = 0,
                 matchFrameHeight = true,
                 size = 50
             }
@@ -587,6 +601,14 @@ function BigDebuffs:OnInitialize()
 
             if type(self.db.profile.unitFrames[key].relativePoint ~= "string") then
                 self.db.profile.unitFrames[key].relativePoint = "auto"
+            end
+
+            if type(self.db.profile.unitFrames[key].x ~= "number") then
+                self.db.profile.unitFrames[key].x = 0
+            end
+
+            if type(self.db.profile.unitFrames[key].y ~= "number") then
+                self.db.profile.unitFrames[key].y = 0
             end
 
             if type(self.db.profile.unitFrames[key].matchFrameHeight ~= "boolean") then
@@ -733,26 +755,26 @@ function BigDebuffs:AttachUnitFrame(unit)
             else
                 if config.relativePoint == "auto" then
                     if config.anchorPoint == "BOTTOM" then
-                        frame:SetPoint("TOP", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("TOP", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "BOTTOMLEFT" then
-                        frame:SetPoint("BOTTOMRIGHT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("BOTTOMRIGHT", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "BOTTOMRIGHT" then
-                        frame:SetPoint("BOTTOMLEFT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("BOTTOMLEFT", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "CENTER" then
-                        frame:SetPoint("CENTER", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("CENTER", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "LEFT" then
-                        frame:SetPoint("RIGHT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("RIGHT", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "RIGHT" then
-                        frame:SetPoint("LEFT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("LEFT", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "TOP" then
-                        frame:SetPoint("BOTTOM", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("BOTTOM", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "TOPLEFT" then
-                        frame:SetPoint("TOPRIGHT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("TOPRIGHT", frame.anchor, config.anchorPoint, config.x, config.y)
                     elseif config.anchorPoint == "TOPRIGHT" then
-                        frame:SetPoint("TOPLEFT", frame.anchor, config.anchorPoint)
+                        frame:SetPoint("TOPLEFT", frame.anchor, config.anchorPoint, config.x, config.y)
                     end
                 else
-                    frame:SetPoint(config.relativePoint, frame.anchor, config.anchorPoint)
+                    frame:SetPoint(config.relativePoint, frame.anchor, config.anchorPoint, config.x, config.y)
                 end
             end
 

--- a/Options.lua
+++ b/Options.lua
@@ -681,6 +681,36 @@ function BigDebuffs:SetupOptions()
                                 },
                                 order = 4,
                             },
+                            x = {
+                                type = "range",
+                                name = L["X offset"],
+                                desc = L["Set the X offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 5,
+                            },
+                            y = {
+                                type = "range",
+                                name = L["Y offset"],
+                                desc = L["Set the Y offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 6,
+                            },
                             matchFrameHeight = {
                                 name = L["Match Frame Height"],
                                 desc = L["Match the height of the frame"],
@@ -689,7 +719,7 @@ function BigDebuffs:SetupOptions()
                                     local name = info[2]
                                     return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                                 end,
-                                order = 5,
+                                order = 7,
                             },
                             size = {
                                 type = "range",
@@ -704,7 +734,7 @@ function BigDebuffs:SetupOptions()
                                 min = 8,
                                 max = 512,
                                 step = 1,
-                                order = 6,
+                                order = 8,
                             },
                         },
                         name = L["Player Frame"],
@@ -790,6 +820,36 @@ function BigDebuffs:SetupOptions()
                                 },
                                 order = 4,
                             },
+                            x = {
+                                type = "range",
+                                name = L["X offset"],
+                                desc = L["Set the X offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 5,
+                            },
+                            y = {
+                                type = "range",
+                                name = L["Y offset"],
+                                desc = L["Set the Y offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 6,
+                            },
                             matchFrameHeight = {
                                 name = L["Match Frame Height"],
                                 desc = L["Match the height of the frame"],
@@ -798,7 +858,7 @@ function BigDebuffs:SetupOptions()
                                     local name = info[2]
                                     return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                                 end,
-                                order = 5,
+                                order = 7,
                             },
                             size = {
                                 type = "range",
@@ -813,7 +873,7 @@ function BigDebuffs:SetupOptions()
                                 min = 8,
                                 max = 512,
                                 step = 1,
-                                order = 6,
+                                order = 8,
                             },
                         },
                         name = L["Target Frame"],
@@ -900,6 +960,36 @@ function BigDebuffs:SetupOptions()
                                 },
                                 order = 4,
                             },
+                            x = {
+                                type = "range",
+                                name = L["X offset"],
+                                desc = L["Set the X offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 5,
+                            },
+                            y = {
+                                type = "range",
+                                name = L["Y offset"],
+                                desc = L["Set the Y offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 6,
+                            },
                             matchFrameHeight = {
                                 name = L["Match Frame Height"],
                                 desc = L["Match the height of the frame"],
@@ -908,7 +998,7 @@ function BigDebuffs:SetupOptions()
                                     local name = info[2]
                                     return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                                 end,
-                                order = 5,
+                                order = 7,
                             },
                             size = {
                                 type = "range",
@@ -923,7 +1013,7 @@ function BigDebuffs:SetupOptions()
                                 min = 8,
                                 max = 512,
                                 step = 1,
-                                order = 6,
+                                order = 8,
                             },
                         },
                         name = L["Pet Frame"],
@@ -1010,6 +1100,36 @@ function BigDebuffs:SetupOptions()
                                 },
                                 order = 4,
                             },
+                            x = {
+                                type = "range",
+                                name = L["X offset"],
+                                desc = L["Set the X offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 5,
+                            },
+                            y = {
+                                type = "range",
+                                name = L["Y offset"],
+                                desc = L["Set the Y offset"],
+                                width = 1.5,
+                                min = -100,
+                                max = 100,
+                                step = 1,
+                                disabled = function(info)
+                                    local name = info[2]
+                                    return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                                        self.db.profile.unitFrames[name].anchorPoint == "auto"
+                                end,
+                                order = 6,
+                            },
                             matchFrameHeight = {
                                 name = L["Match Frame Height"],
                                 desc = L["Match the height of the frame"],
@@ -1018,7 +1138,7 @@ function BigDebuffs:SetupOptions()
                                     local name = info[2]
                                     return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                                 end,
-                                order = 5,
+                                order = 7,
                             },
                             size = {
                                 type = "range",
@@ -1033,7 +1153,7 @@ function BigDebuffs:SetupOptions()
                                 min = 8,
                                 max = 512,
                                 step = 1,
-                                order = 6,
+                                order = 8,
                             },
                         },
                         name = L["Party Frames"],
@@ -1540,6 +1660,36 @@ function BigDebuffs:SetupOptions()
                     },
                     order = 4,
                 },
+                x = {
+                    type = "range",
+                    name = L["X offset"],
+                    desc = L["Set the X offset"],
+                    width = 1.5,
+                    min = -100,
+                    max = 100,
+                    step = 1,
+                    disabled = function(info)
+                        local name = info[2]
+                        return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                            self.db.profile.unitFrames[name].anchorPoint == "auto"
+                    end,
+                    order = 5,
+                },
+                y = {
+                    type = "range",
+                    name = L["Y offset"],
+                    desc = L["Set the Y offset"],
+                    width = 1.5,
+                    min = -100,
+                    max = 100,
+                    step = 1,
+                    disabled = function(info)
+                        local name = info[2]
+                        return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                            self.db.profile.unitFrames[name].anchorPoint == "auto"
+                    end,
+                    order = 6,
+                },
                 matchFrameHeight = {
                     name = L["Match Frame Height"],
                     desc = L["Match the height of the frame"],
@@ -1548,7 +1698,7 @@ function BigDebuffs:SetupOptions()
                         local name = info[2]
                         return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                     end,
-                    order = 5,
+                    order = 7,
                 },
                 size = {
                     type = "range",
@@ -1563,7 +1713,7 @@ function BigDebuffs:SetupOptions()
                     min = 8,
                     max = 512,
                     step = 1,
-                    order = 6,
+                    order = 8,
                 },
             },
             name = L["Focus Frame"],
@@ -1651,6 +1801,36 @@ function BigDebuffs:SetupOptions()
                     },
                     order = 4,
                 },
+                x = {
+                    type = "range",
+                    name = L["X offset"],
+                    desc = L["Set the X offset"],
+                    width = 1.5,
+                    min = -100,
+                    max = 100,
+                    step = 1,
+                    disabled = function(info)
+                        local name = info[2]
+                        return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                            self.db.profile.unitFrames[name].anchorPoint == "auto"
+                    end,
+                    order = 5,
+                },
+                y = {
+                    type = "range",
+                    name = L["Y offset"],
+                    desc = L["Set the Y offset"],
+                    width = 1.5,
+                    min = -100,
+                    max = 100,
+                    step = 1,
+                    disabled = function(info)
+                        local name = info[2]
+                        return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual" or
+                            self.db.profile.unitFrames[name].anchorPoint == "auto"
+                    end,
+                    order = 6,
+                },
                 matchFrameHeight = {
                     name = L["Match Frame Height"],
                     desc = L["Match the height of the frame"],
@@ -1659,7 +1839,7 @@ function BigDebuffs:SetupOptions()
                         local name = info[2]
                         return not self.db.profile.unitFrames[name].enabled or self.db.profile.unitFrames[name].anchor == "manual"
                     end,
-                    order = 5,
+                    order = 7,
                 },
                 size = {
                     type = "range",
@@ -1674,7 +1854,7 @@ function BigDebuffs:SetupOptions()
                     min = 8,
                     max = 512,
                     step = 1,
-                    order = 6,
+                    order = 8,
                 },
             },
             name = L["Arena Frames"],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20967811/111291030-0afbb480-8647-11eb-962a-850b543ce332.png)

Adds offset options for unit frame anchors - missed it in https://github.com/jordonwow/bigdebuffs/pull/253. Now the customization options should be complete.