### PR TITLE
Fix #261: party frames showing in large raid groups

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1793,7 +1793,8 @@ end
 
 function BigDebuffs:UNIT_AURA(unit)
     if not self.db.profile.unitFrames.enabled or
-        not self.db.profile.unitFrames[unit:gsub("%d", "")].enabled
+        not self.db.profile.unitFrames[unit:gsub("%d", "")].enabled or
+        (GetNumGroupMembers() > 5 and unit:match("party"))
     then
         return
     end


### PR DESCRIPTION
When using manually anchored party frames, they should no longer show while in a raid group larger than 5 players.