### PR TITLE
fix: dont anchor arena debuffs to hidden elvui frames

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -344,6 +344,19 @@ local GetAnchor = {
             return
         end
 
+        if unit and ( unit:match("arena") or unit:match("arena") ) then
+            local unitGUID = UnitGUID(unit)
+            for i = 1,5,1 do
+                local elvUIFrame = _G["ElvUF_Arena"..i]
+                if elvUIFrame and elvUIFrame:IsVisible() and elvUIFrame.unit then
+                    if unitGUID == UnitGUID(elvUIFrame.unit) then
+                        return elvUIFrame
+                    end
+                end
+            end
+            return
+        end
+
         return _G[anchor]
     end,
     ShadowedUnitFrames = function(anchor)


### PR DESCRIPTION
Currently, BigDebuffs get anchored to ElvUI arena frames although they are disabled.
This PR applies the mechanism preventing this bug from happening with party frames to arena frames.

Quite possibly this bug affects player/target/raid as well.