### PR TITLE
Retail spell updates / polish

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -61,25 +61,24 @@ addon.Spells = {
     [6552] = { type = INTERRUPT, duration = 4 }, -- Pummel (Warrior)
     [19647] = { type = INTERRUPT, duration = 6 }, -- Spell Lock (Warlock)
         [132409] = { type = INTERRUPT, duration = 6, parent = 19647 }, -- Spell Lock (Warlock)
-        [171138] = { type = INTERRUPT, duration = 6, parent = 19647 }, -- Shadow Lock (Warlock)
     [47528] = { type = INTERRUPT, duration = 3 }, -- Mind Freeze (Death Knight)
     [57994] = { type = INTERRUPT, duration = 3 }, -- Wind Shear (Shaman)
-    [91802] = { type = INTERRUPT, duration = 2 }, -- Shambling Rush (Death Knight)
+    [91807] = { type = INTERRUPT, duration = 2 }, -- Shambling Rush (Death Knight)
     [96231] = { type = INTERRUPT, duration = 4 }, -- Rebuke (Paladin)
-    [106839] = { type = INTERRUPT, duration = 4 }, -- Skull Bash (Feral)
-        [93985] = { type = INTERRUPT, duration = 4, parent = 106839 }, -- Skull Bash (Feral)
-    [115781] = { type = INTERRUPT, duration = 6 }, -- Optical Blast (Warlock)
+    [93985] = { type = INTERRUPT, duration = 4 }, -- Skull Bash (Feral/Guardian)
     [116705] = { type = INTERRUPT, duration = 4 }, -- Spear Hand Strike (Monk)
-    [147362] = { type = INTERRUPT, duration = 3 }, -- Countershot (Hunter)
+    [147362] = { type = INTERRUPT, duration = 3 }, -- Counter Shot (Hunter)
     [183752] = { type = INTERRUPT, duration = 3 }, -- Disrupt (Demon Hunter)
     [187707] = { type = INTERRUPT, duration = 3 }, -- Muzzle (Hunter)
     [212619] = { type = INTERRUPT, duration = 6 }, -- Call Felhunter (Warlock)
-    [231665] = { type = INTERRUPT, duration = 3 }, -- Avengers Shield (Paladin)
+    [31935] = { type = INTERRUPT, duration = 3 }, -- Avenger's Shield (Paladin)
+    [217824] = { type = INTERRUPT, duration = 4 }, -- Shield of Virtue (Protection PvP Talent)
 
     -- Death Knight
 
     [47476] = { type = CROWD_CONTROL }, -- Strangulate
     [48707] = { type = IMMUNITY_SPELL }, -- Anti-Magic Shell
+    [145629] = { type = BUFF_DEFENSIVE }, -- Anti-Magic Zone
     [48265] = { type = BUFF_SPEED_BOOST }, -- Death's Advance
     [48792] = { type = BUFF_DEFENSIVE }, -- Icebound Fortitude
     [49039] = { type = BUFF_OTHER }, -- Lichborne
@@ -87,8 +86,9 @@ addon.Spells = {
     [51271] = { type = BUFF_OFFENSIVE }, -- Pillar of Frost
     [55233] = { type = BUFF_DEFENSIVE }, -- Vampiric Blood
     [77606] = { type = DEBUFF_OFFENSIVE }, -- Dark Simulacrum
-    [91797] = { type = CROWD_CONTROL }, -- Monstrous Blow
+    [63560] = { type = BUFF_OFFENSIVE }, -- Dark Transformation
     [91800] = { type = CROWD_CONTROL }, -- Gnaw
+        [91797] = { type = CROWD_CONTROL, parent = 91800 }, -- Monstrous Blow
     [108194] = { type = CROWD_CONTROL }, -- Asphyxiate
         [221562] = { type = CROWD_CONTROL, parent = 108194 }, -- Asphyxiate (Blood)
     [152279] = { type = BUFF_OFFENSIVE }, -- Breath of Sindragosa
@@ -104,13 +104,16 @@ addon.Spells = {
     [212552] = { type = BUFF_SPEED_BOOST }, -- Wraith Walk
     [219809] = { type = BUFF_DEFENSIVE }, -- Tombstone
     [223929] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Necrotic Wound
+    [343294] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Soul Reaper
     [321995] = { type = BUFF_OFFENSIVE }, -- Hypothermic Presence
-    [334693] = { type = CROWD_CONTROL }, -- Absolute Zero
+    [334693] = { type = CROWD_CONTROL }, -- Absolute Zero (Frost Legendary)
+    [206961] = { type = CROWD_CONTROL }, -- Tremble Before Me (Phearamones Legendary)
     [91807] = { type = ROOT }, -- Shambling Rush
     [210141] = { type = CROWD_CONTROL}, -- Zombie Explosion (Reanimation Unholy PvP Talent)
     [288849] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Crypt Fever (Necromancer's Bargain Unholy PvP Talent)
     [3714] = { type = BUFF_OTHER }, -- Path of Frost
-    [315443] = { type = BUFF_OFFENSIVE }, -- Abomination Limb
+    [315443] = { type = BUFF_OFFENSIVE }, -- Abomination Limb (Necrolord Ability)
+    [311648] = { type = BUFF_OFFENSIVE }, -- Swarming Mist (Venthyr Ability)
 
     -- Demon Hunter
 
@@ -121,7 +124,6 @@ addon.Spells = {
     [204490] = { type = CROWD_CONTROL }, -- Sigil of Silence
     [205629] = { type = BUFF_DEFENSIVE }, -- Demonic Trample
     [213491] = { type = CROWD_CONTROL }, -- Demonic Trample (short stun on targets)
-        [208645] = { type = CROWD_CONTROL, parent = 213491 }, -- Demonic Trample (short stun on targets)
     [205630] = { type = CROWD_CONTROL }, -- Illidan's Grasp - Grab
         [208618] = { type = CROWD_CONTROL, parent = 205630 }, -- Illidan's Grasp - Stun
     [206649] = { type = DEBUFF_OFFENSIVE }, -- Eye of Leotheras
@@ -135,13 +137,14 @@ addon.Spells = {
     [217832] = { type = CROWD_CONTROL }, -- Imprison
         [221527] = { type = CROWD_CONTROL, parent = 217832 }, -- Imprison (PvP Talent)
     [203704] = { type = DEBUFF_OFFENSIVE }, -- Mana Break
+    [337567] = { type = BUFF_OFFENSIVE }, -- Chaotic Blades (Chaos Theory Legendary)
+    [323996] = { type = CROWD_CONTROL }, -- The Hunt (Night Fae Ability)
 
     -- Druid
 
     [99] = { type = CROWD_CONTROL }, -- Incapacitating Roar
     [339] = { type = ROOT }, -- Entangling Roots
         [170855] = { type = ROOT, parent = 339 }, -- Entangling Roots (Nature's Grasp)
-    [740] = { type = BUFF_DEFENSIVE }, -- Tranquility
     [1850] = { type = BUFF_SPEED_BOOST }, -- Dash
         [252216] = { type = BUFF_SPEED_BOOST, parent = 1850 }, -- Tiger Dash
     [2637] = { type = CROWD_CONTROL }, -- Hibernate
@@ -151,7 +154,8 @@ addon.Spells = {
     [22842] = { type = BUFF_DEFENSIVE }, -- Frenzied Regeneration
     [29166] = { type = BUFF_OFFENSIVE }, -- Innervate
     [33786] = { type = CROWD_CONTROL }, -- Cyclone
-    [117679] = { type = BUFF_OFFENSIVE }, -- Incarnation (grants access to Tree of Life form)
+    [33891] = { type = BUFF_OFFENSIVE }, -- Incarnation: Tree of Life (for the menu entry - "Incarnation" tooltip isn't informative)
+        [117679] = { type = BUFF_OFFENSIVE, parent = 33891 }, -- Incarnation (grants access to Tree of Life form)
     [45334] = { type = ROOT }, -- Immobilized (Wild Charge in Bear Form)
     [61336] = { type = BUFF_DEFENSIVE }, -- Survival Instincts
     [81261] = { type = CROWD_CONTROL }, -- Solar Beam
@@ -160,16 +164,14 @@ addon.Spells = {
     [102543] = { type = BUFF_OFFENSIVE }, -- Incarnation: King of the Jungle
     [102558] = { type = BUFF_OFFENSIVE }, -- Incarnation: Guardian of Ursoc
     [102560] = { type = BUFF_OFFENSIVE }, -- Incarnation: Chosen of Elune
-    [106951] = { type = BUFF_OFFENSIVE }, -- Berserk
+    [106951] = { type = BUFF_OFFENSIVE }, -- Berserk (Feral)
     [132158] = { type = BUFF_OFFENSIVE }, -- Nature's Swiftness
     [155835] = { type = BUFF_DEFENSIVE }, -- Bristling Fur
-    [192081] = { type = BUFF_DEFENSIVE }, -- Ironfur
     [163505] = { type = CROWD_CONTROL }, -- Rake
     [194223] = { type = BUFF_OFFENSIVE }, -- Celestial Alignment
     [202425] = { type = BUFF_OFFENSIVE }, -- Warrior of Elune
-    [209749] = { type = CROWD_CONTROL }, -- Faerie Swarm (Slow/Disarm)
-    [22570] = { type = CROWD_CONTROL }, -- Maim
-        [203123] = { type = CROWD_CONTROL, parent = 22570 }, -- Maim
+    [209749] = { type = CROWD_CONTROL }, -- Faerie Swarm
+    [203123] = { type = CROWD_CONTROL }, -- Maim
     [305497] = { type = BUFF_DEFENSIVE }, -- Thorns (PvP Talent)
     [50334] = { type = BUFF_DEFENSIVE }, -- Berserk (Guardian)
     [127797] = { type = CROWD_CONTROL, nounitFrames = true, nonameplates = true }, -- Ursol's Vortex
@@ -184,7 +186,10 @@ addon.Spells = {
         [108293] = { type = BUFF_OFFENSIVE, parent = 319454 }, -- with Guardian Affinity
         [108294] = { type = BUFF_OFFENSIVE, parent = 319454 }, -- with Resto Affinity
     [5215] = { type = BUFF_OTHER }, -- Prowl
-    [323764] = { type = BUFF_OFFENSIVE }, -- Convoke the Spirits
+    [323764] = { type = BUFF_OFFENSIVE }, -- Convoke the Spirits (Night Fae Ability)
+    [323546] = { type = BUFF_OFFENSIVE }, -- Ravenous Frenzy (Venthyr Ability)
+    [338142] = { type = BUFF_OFFENSIVE }, -- Lone Empowerment (Kyrian Ability)
+    [327037] = { type = BUFF_DEFENSIVE }, -- Kindred Protection (Kyrian Ability)
 
     -- Hunter
 
@@ -195,42 +200,37 @@ addon.Spells = {
     [5384] = { type = BUFF_DEFENSIVE }, -- Feign Death
     [19574] = { type = BUFF_OFFENSIVE }, -- Bestial Wrath
         [186254] = { type = BUFF_OFFENSIVE, parent = 19574 }, -- Bestial Wrath buff on the pet
-    [19577] = { type = CROWD_CONTROL }, -- Intimidation
-        [24394] = { type = CROWD_CONTROL, parent = 19577 }, -- Intimidation
-    [53480] = { type = BUFF_DEFENSIVE }, -- Roar of Sacrifice (Hunter Pet Skill)
+    [24394] = { type = CROWD_CONTROL }, -- Intimidation
+    [53480] = { type = BUFF_DEFENSIVE }, -- Roar of Sacrifice (PvP Talent)
     [54216] = { type = BUFF_DEFENSIVE }, -- Master's Call
     [117526] = { type = ROOT }, -- Binding Shot
-        [117405] = { type = ROOT, parent = 117526 }, -- Binding Shot - aura when you're in the area
+    [117405] = { type = ROOT, nounitFrames = true, nonameplates = true }, -- Binding Shot - aura when you're in the area
     [118922] = { type = BUFF_SPEED_BOOST }, -- Posthaste
     [131894] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- A Murder of Crows
     [162480] = { type = ROOT }, -- Steel Trap
     [186257] = { type = BUFF_SPEED_BOOST }, -- Aspect of the Cheetah
-        [203233] = { type = BUFF_SPEED_BOOST, parent = 186257 }, -- Hunting Pack PvP Talent
-    [186265] = { type = BUFF_DEFENSIVE }, -- Aspect of the Turtle
+        [203233] = { type = BUFF_SPEED_BOOST, parent = 186257 }, -- Hunting Pack (PvP Talent)
+    [186265] = { type = IMMUNITY }, -- Aspect of the Turtle
     [186289] = { type = BUFF_OFFENSIVE }, -- Aspect of the Eagle
-    [238559] = { type = CROWD_CONTROL }, -- Bursting Shot
-        [186387] = { type = CROWD_CONTROL, parent = 238559 }, -- Bursting Shot
     [193530] = { type = BUFF_OFFENSIVE }, -- Aspect of the Wild
-    [199483] = { type = BUFF_DEFENSIVE }, -- Camouflage
+    [199483] = { type = BUFF_OTHER }, -- Camouflage
     [202914] = { type = CROWD_CONTROL }, -- Spider Sting (Armed)
         [202933] = { type = CROWD_CONTROL, parent = 202914 }, -- Spider Sting (Silenced)
-        [233022] = { type = CROWD_CONTROL, parent = 202914 }, -- Spider Sting (Silenced)
     [209997] = { type = BUFF_DEFENSIVE }, -- Play Dead
     [212638] = { type = ROOT }, -- Tracker's Net
     [213691] = { type = CROWD_CONTROL }, -- Scatter Shot
     [260402] = { type = BUFF_OFFENSIVE }, -- Double Tap
-    [264667] = { type = BUFF_OFFENSIVE }, -- Primal Rage
     [266779] = { type = BUFF_OFFENSIVE }, -- Coordinated Assault
     [288613] = { type = BUFF_OFFENSIVE }, -- Trueshot
     [190925] = { type = ROOT }, -- Harpoon
-    [202748] = { type = BUFF_DEFENSIVE }, -- Survival Tactics
-    [248519] = { type = BUFF_DEFENSIVE }, -- Interlope (PvP Talent)
+    [202748] = { type = BUFF_DEFENSIVE }, -- Survival Tactics (PvP Talent)
+    [248519] = { type = IMMUNITY_SPELL }, -- Interlope (BM PvP Talent)
 
     -- Mage
 
-    [66] = { type = BUFF_OFFENSIVE }, -- Invisibility
+    [66] = { type = BUFF_OFFENSIVE }, -- Invisibility (Countdown)
         [32612] = { type = BUFF_OFFENSIVE, parent = 66 }, -- Invisibility
-        [110960] = { type = BUFF_OFFENSIVE, parent = 66 }, -- Greater Invisibility
+        [113862] = { type = BUFF_OFFENSIVE, parent = 66 }, -- Greater Invisibility
     [118] = { type = CROWD_CONTROL }, -- Polymorph
         [28271] = { type = CROWD_CONTROL, parent = 118 }, -- Polymorph Turtle
         [28272] = { type = CROWD_CONTROL, parent = 118 }, -- Polymorph Pig
@@ -247,32 +247,31 @@ addon.Spells = {
         [277792] = { type = CROWD_CONTROL, parent = 118 }, -- Polymorph Bumblebee
     [122] = { type = ROOT }, -- Frost Nova
     [33395] = { type = ROOT }, -- Freeze
-    --[11426] = { type = BUFF_DEFENSIVE }, -- Ice Barrier (covers up combustion, doesn't provide much information)
     [12042] = { type = BUFF_OFFENSIVE }, -- Arcane Power
     [12051] = { type = BUFF_OFFENSIVE }, -- Evocation
     [12472] = { type = BUFF_OFFENSIVE }, -- Icy Veins
         [198144] = { type = BUFF_OFFENSIVE, parent = 12472 }, -- Ice Form
     [31661] = { type = CROWD_CONTROL }, -- Dragon's Breath
     [45438] = { type = IMMUNITY }, -- Ice Block
-        [41425] = { type = BUFF_OTHER }, -- Hypothermia
-    [80353] = { type = BUFF_OFFENSIVE }, -- Time Warp
+    [41425] = { type = BUFF_OTHER }, -- Hypothermia
     [342242] = { type = BUFF_OFFENSIVE }, -- Time Warp procced by Time Anomality (Arcane Talent)
     [82691] = { type = CROWD_CONTROL }, -- Ring of Frost
     [87023] = { type = BUFF_OTHER }, -- Cauterize
-    [108839] = { type = BUFF_OFFENSIVE }, -- Ice Floes
+    [108839] = { type = BUFF_OTHER }, -- Ice Floes
     [342246] = { type = BUFF_DEFENSIVE }, -- Alter Time (Arcane)
         [110909] = { type = BUFF_DEFENSIVE, parent = 342246 }, -- Alter Time (Fire/Frost)
     [157997] = { type = ROOT }, -- Ice Nova
     [190319] = { type = BUFF_OFFENSIVE }, -- Combustion
-    [198111] = { type = BUFF_DEFENSIVE }, -- Temporal Shield
-    [198158] = { type = BUFF_OFFENSIVE }, -- Mass Invisibility
-    [198064] = { type = BUFF_DEFENSIVE }, -- Prismatic Cloak
-        [198065] = { type = BUFF_DEFENSIVE, parent = 198064 }, -- Prismatic Cloak
+    [198111] = { type = BUFF_DEFENSIVE }, -- Temporal Shield (Arcane PvP Talent)
+    [198158] = { type = BUFF_OFFENSIVE }, -- Mass Invisibility (Arcane PvP Talent)
+    [198065] = { type = BUFF_DEFENSIVE }, -- Prismatic Cloak (PvP Talent)
     [205025] = { type = BUFF_OFFENSIVE }, -- Presence of Mind
     [228600] = { type = ROOT }, -- Glacial Spike Root
     [317589] = { type = CROWD_CONTROL }, -- Tormenting Backlash (Venthyr Ability)
-    [198121] = { type = ROOT }, -- Frostbite (PvP Talent)
+    [198121] = { type = ROOT }, -- Frostbite (Frost PvP Talent)
     [130] = { type = BUFF_OTHER }, -- Slow Fall
+    [333100] = { type = BUFF_OFFENSIVE }, -- Firestorm (Fire Legendary)
+    [324220] = { type = BUFF_OFFENSIVE }, -- Deathborne (Necrolord Ability)
 
     -- Monk
 
@@ -282,24 +281,26 @@ addon.Spells = {
         [243435] = { type = BUFF_DEFENSIVE, parent = 120954 }, -- Fortifying Brew (Windwalker/Mistweaver)
     [116706] = { type = ROOT }, -- Disable
     [116841] = { type = BUFF_SPEED_BOOST }, -- Tiger's Lust
+    [337294] = { type = BUFF_DEFENSIVE }, -- Roll Out (Legendary)
     [116849] = { type = BUFF_DEFENSIVE }, -- Life Cocoon
     [119381] = { type = CROWD_CONTROL }, -- Leg Sweep
+    [324382] = { type = CROWD_CONTROL }, -- Clash
     [122278] = { type = BUFF_DEFENSIVE }, -- Dampen Harm
-    [122470] = { type = BUFF_DEFENSIVE }, -- Touch of Karma (Debuff)
-        [125174] = { type = BUFF_DEFENSIVE, parent = 122470 }, -- Touch of Karma (Buff)
+    [125174] = { type = BUFF_DEFENSIVE }, -- Touch of Karma (Buff)
+    [122470] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Touch of Karma (Debuff)
     [122783] = { type = BUFF_DEFENSIVE }, -- Diffuse Magic
     [137639] = { type = BUFF_OFFENSIVE }, -- Storm, Earth, and Fire
     [152173] = { type = BUFF_OFFENSIVE }, -- Serenity
     [198909] = { type = CROWD_CONTROL }, -- Song of Chi-Ji
-    [202162] = { type = BUFF_DEFENSIVE }, -- Avert Harm
-    [202274] = { type = CROWD_CONTROL }, -- Incendiary Brew
-    [209584] = { type = BUFF_DEFENSIVE }, -- Zen Focus Tea
-    [233759] = { type = CROWD_CONTROL }, -- Grapple Weapon
-    [247483] = { type = BUFF_OFFENSIVE }, -- Tigereye Brew
+    [202162] = { type = BUFF_DEFENSIVE }, -- Avert Harm (Brew PvP Talent)
+    [202274] = { type = CROWD_CONTROL }, -- Incendiary Brew (Brew PvP Talent)
+    [209584] = { type = BUFF_DEFENSIVE }, -- Zen Focus Tea (MW PvP Talent)
+    [233759] = { type = CROWD_CONTROL }, -- Grapple Weapon (MW/WW PvP Talent)
+    [343249] = { type = BUFF_DEFENSIVE }, -- Escape from Reality (MW Monk Legendary)
     [310454] = { type = BUFF_OFFENSIVE }, -- Weapons of Order (Kyrian Ability)
+    [202335] = { type = BUFF_OFFENSIVE }, -- Double Barrel (Brew PvP Talent) - "next cast will..." buff
     [202346] = { type = CROWD_CONTROL }, -- Double Barrel (Brew PvP Talent)
-    [325153] = { type = CROWD_CONTROL }, -- Exploding Keg
-    [202248] = { type = BUFF_DEFENSIVE }, -- Guided Meditation (Brew PvP Talent)
+    [202248] = { type = IMMUNITY_SPELL }, -- Guided Meditation (Brew PvP Talent)
     [213664] = { type = BUFF_DEFENSIVE }, -- Nimble Brew (Brew PvP Talent)
     [132578] = { type = BUFF_DEFENSIVE }, -- Invoke Niuzao, the Black Ox
 
@@ -309,13 +310,14 @@ addon.Spells = {
     [642] = { type = IMMUNITY }, -- Divine Shield
     [853] = { type = CROWD_CONTROL }, -- Hammer of Justice
     [1022] = { type = BUFF_DEFENSIVE }, -- Blessing of Protection
-        [204018] = { type = BUFF_DEFENSIVE }, -- Blessing of Spellwarding
+    [204018] = { type = BUFF_DEFENSIVE }, -- Blessing of Spellwarding
     [1044] = { type = BUFF_DEFENSIVE }, -- Blessing of Freedom
         [305395] = { type = BUFF_DEFENSIVE, parent = 1044 }, -- Blessing of Freedom with Unbound Freedom (PvP Talent)
     [6940] = { type = BUFF_DEFENSIVE }, -- Blessing of Sacrifice
-        [199448] = { type = BUFF_DEFENSIVE, parent = 6940 }, -- Blessing of Sacrifice (Ultimate Sacrifice PvP Talent)
-        [199450] = { type = BUFF_DEFENSIVE, parent = 6940 }, -- Blessing of Sacrifice (Ultimate Sacrifice Damage)
+    [199448] = { type = BUFF_DEFENSIVE }, -- Blessing of Sacrifice (Ultimate Sacrifice Holy PvP Talent)
+        [199450] = { type = BUFF_DEFENSIVE, parent = 199448 }, -- Ultimate Sacrifice (Holy PvP Talent) - debuff on the paladin
     [20066] = { type = CROWD_CONTROL }, -- Repentance
+    [10326] = { type = CROWD_CONTROL }, -- Turn Evil
     [25771] = { type = BUFF_OTHER }, -- Forbearance
     [31821] = { type = BUFF_DEFENSIVE }, -- Aura Mastery
     [31850] = { type = BUFF_DEFENSIVE }, -- Ardent Defender
@@ -325,18 +327,17 @@ addon.Spells = {
     [31935] = { type = CROWD_CONTROL }, -- Avenger's Shield
     [86659] = { type = BUFF_DEFENSIVE }, -- Guardian of Ancient Kings
         [212641] = { type = BUFF_DEFENSIVE, parent = 86659 }, -- Guardian of Ancient Kings (Glyphed)
-        [228050] = { type = IMMUNITY }, -- Guardian of the Forgotten Queen
+    [228050] = { type = IMMUNITY }, -- Guardian of the Forgotten Queen (Protection PvP Talent)
     [105809] = { type = BUFF_OFFENSIVE }, -- Holy Avenger
-    [115750] = { type = CROWD_CONTROL }, -- Blinding Light
-        [105421] = { type = CROWD_CONTROL, parent = 115750 }, -- Blinding Light
+    [105421] = { type = CROWD_CONTROL }, -- Blinding Light
     [152262] = { type = BUFF_OFFENSIVE }, -- Seraphim
     [184662] = { type = BUFF_DEFENSIVE }, -- Shield of Vengeance
     [199545] = { type = BUFF_DEFENSIVE }, -- Steed of Glory (Protection PvP Talent)
     [205191] = { type = BUFF_DEFENSIVE }, -- Eye for an Eye
-    [210256] = { type = BUFF_DEFENSIVE }, -- Blessing of Sanctuary
-    [210294] = { type = BUFF_DEFENSIVE }, -- Divine Favor
-    [215652] = { type = BUFF_OFFENSIVE }, -- Shield of Virtue (Buff)
-        [217824] = { type = CROWD_CONTROL, parent = 215652 }, -- Shield of Virtue (Debuff)
+    [210256] = { type = BUFF_DEFENSIVE }, -- Blessing of Sanctuary (Ret PvP Talent)
+    [210294] = { type = BUFF_DEFENSIVE }, -- Divine Favor (Holy PvP Talent)
+    [215652] = { type = BUFF_OFFENSIVE }, -- Shield of Virtue (Protection PvP Talent) - "next cast will..." buff
+    [217824] = { type = CROWD_CONTROL }, -- Shield of Virtue (Protection PvP Talent)
     [221883] = { type = BUFF_SPEED_BOOST }, -- Divine Steed (Human?) (Each race has its own buff, pulled from wowhead - some might be incorrect)
         [221885] = { type = BUFF_SPEED_BOOST, parent =  221883 }, -- Divine Steed (Tauren?)
         [221886] = { type = BUFF_SPEED_BOOST, parent =  221883 }, -- Divine Steed (Blood Elf?)
@@ -354,7 +355,7 @@ addon.Spells = {
     -- Priest
 
     [337661] = { type = BUFF_DEFENSIVE }, -- Translucent Image (Fade defensive Conduit)
-    [213602] = { type = BUFF_DEFENSIVE }, -- Greater Fade
+    [213602] = { type = BUFF_DEFENSIVE }, -- Greater Fade (Holy/Shadow PvP Talent)
     [605] = { type = CROWD_CONTROL, priority = true }, -- Mind Control
     [8122] = { type = CROWD_CONTROL }, -- Psychic Scream
     [9484] = { type = CROWD_CONTROL }, -- Shackle Undead
@@ -370,22 +371,22 @@ addon.Spells = {
     [81782] = { type = BUFF_DEFENSIVE }, -- Power Word: Barrier
     [87204] = { type = CROWD_CONTROL }, -- Sin and Punishment
     [194249] = { type = BUFF_OFFENSIVE }, -- Voidform
-    [232707] = { type = BUFF_DEFENSIVE }, -- Ray of Hope
-    [197862] = { type = BUFF_DEFENSIVE }, -- Archangel
-    [197871] = { type = BUFF_OFFENSIVE }, -- Dark Archangel (on the priest)
-    [197874] = { type = BUFF_OFFENSIVE }, -- Dark Archangel (on others)
+    [232707] = { type = BUFF_DEFENSIVE }, -- Ray of Hope (Holy PvP Talent)
+    [197862] = { type = BUFF_DEFENSIVE }, -- Archangel (Disc PvP Talent)
+    [197871] = { type = BUFF_OFFENSIVE }, -- Dark Archangel (Disc PvP Talent) - on the priest
+        [197874] = { type = BUFF_OFFENSIVE, parent = 197871 }, -- Dark Archangel (Disc PvP Talent) - on others
     [200183] = { type = BUFF_DEFENSIVE }, -- Apotheosis
     [200196] = { type = CROWD_CONTROL }, -- Holy Word: Chastise
         [200200] = { type = CROWD_CONTROL, parent = 200196 }, -- Holy Word: Chastise (Stun)
-    [205369] = { type = CROWD_CONTROL }, -- Mind Bomb
+    [205369] = { type = CROWD_CONTROL }, -- Mind Bomb (Countdown)
         [226943] = { type = CROWD_CONTROL, parent = 205369 }, -- Mind Bomb (Disorient)
     [213610] = { type = BUFF_DEFENSIVE }, -- Holy Ward
-    [27827] = { type = BUFF_DEFENSIVE }, -- Spirit of Redemption
-        [215769] = { type = BUFF_DEFENSIVE, parent = 27827 }, -- Spirit of the Redeemer PvP Talent
+    --[27827] = { type = BUFF_DEFENSIVE }, -- Spirit of Redemption
+    [215769] = { type = BUFF_DEFENSIVE }, -- Spirit of Redemption (Spirit of the Redeemer Holy PvP Talent)
     [211336] = { type = BUFF_DEFENSIVE }, -- Archbishop Benedictus' Restitution (Holy Priest Revive Legendary)
     [289655] = { type = BUFF_DEFENSIVE }, -- Holy Word: Concentration
     [319952] = { type = BUFF_OFFENSIVE }, -- Surrender to Madness
-    [322431] = { type = BUFF_OFFENSIVE, nounitFrames = true, noraidFrames = true, nonameplates = true }, -- Thoughtsteal (Buff)
+    [322431] = { type = BUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Thoughtsteal (Buff)
     [322459] = { type = DEBUFF_OFFENSIVE }, -- Thoughtstolen (Shaman)
         [322464] = { type = DEBUFF_OFFENSIVE, parent = 322459 }, -- Thoughtstolen (Mage)
         [322442] = { type = DEBUFF_OFFENSIVE, parent = 322459 }, -- Thoughtstolen (Druid)
@@ -395,11 +396,12 @@ addon.Spells = {
         [322461] = { type = DEBUFF_OFFENSIVE, parent = 322459 }, -- Thoughtstolen (Priest - Discipline)
         [322458] = { type = DEBUFF_OFFENSIVE, parent = 322459 }, -- Thoughtstolen (Monk)
         [322460] = { type = DEBUFF_OFFENSIVE, parent = 322459 }, -- Thoughtstolen (Priest - Shadow)
-    [323673] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Mindgames
-    [329543] = { type = BUFF_DEFENSIVE }, -- Divine Ascension
-        [328530] = { type = IMMUNITY, parent = 329543 }, -- Divine Ascension
+    [323673] = { type = DEBUFF_OFFENSIVE }, -- Mindgames
+    [329543] = { type = BUFF_DEFENSIVE }, -- Divine Ascension (down)
+        [328530] = { type = IMMUNITY, parent = 329543 }, -- Divine Ascension (up)
     [335467] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Devouring Plague
-    [453] = { type = DEBUFF_OFFENSIVE, noraidFrames = true }, -- Mind Soothe
+    [34914] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Vampiric Touch
+    [453] = { type = BUFF_OTHER, noraidFrames = true }, -- Mind Soothe
     [15286] = { type = BUFF_DEFENSIVE }, -- Vampiric Embrace
     [19236] = { type = BUFF_DEFENSIVE }, -- Desperate Prayer
     [111759] = { type = BUFF_OTHER }, -- Levitate
@@ -417,6 +419,7 @@ addon.Spells = {
     [1966] = { type = BUFF_DEFENSIVE }, -- Feint
     [2094] = { type = CROWD_CONTROL }, -- Blind
     [2983] = { type = BUFF_SPEED_BOOST }, -- Sprint
+    [36554] = { type = BUFF_SPEED_BOOST }, -- Shadowstep
     [5277] = { type = BUFF_DEFENSIVE }, -- Evasion
     [6770] = { type = CROWD_CONTROL }, -- Sap
     [11327] = { type = BUFF_DEFENSIVE }, -- Vanish
@@ -428,23 +431,26 @@ addon.Spells = {
     [121471] = { type = BUFF_OFFENSIVE }, -- Shadow Blades
     [185422] = { type = BUFF_OFFENSIVE }, -- Shadow Dance
     [207736] = { type = BUFF_OFFENSIVE }, -- Shadowy Duel
+    [212283] = { type = BUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Symbols of Death
     [207777] = { type = CROWD_CONTROL }, -- Dismantle
-    [212183] = { type = CROWD_CONTROL }, -- Smoke Bomb
-    [212150] = { type = CROWD_CONTROL }, -- Cheap Tricks (Outlaw PvP Talent, Blind effect)
-    [197091] = { type = CROWD_CONTROL }, -- Neurotoxin (Assa PvP Talent)
+    [212183] = { type = CROWD_CONTROL }, -- Smoke Bomb (PvP Talent)
+    [212150] = { type = CROWD_CONTROL }, -- Cheap Tricks (Outlaw PvP Talent)
     [199027] = { type = BUFF_DEFENSIVE }, -- Veil of Midnight (Subtlety PvP Talent)
     [197003] = { type = BUFF_DEFENSIVE }, -- Maneuverability (PvP Talent)
     [1784] = { type = BUFF_OTHER }, -- Stealth
         [115191] = { type = BUFF_OTHER, parent = 1784 }, -- Stealth (with Subterfuge talented)
+    [115192] = { type = BUFF_OFFENSIVE }, -- Subterfuge
+    [256735] = { type = BUFF_OFFENSIVE }, -- Master Assassin
+    [340094] = { type = BUFF_OFFENSIVE }, -- Master Assassin's Mark (Legendary)
+    [345569] = { type = BUFF_OFFENSIVE }, -- Flagellation (Venthyr Ability)
+    [347037] = { type = BUFF_OFFENSIVE }, -- Sepsis (Night Fae Ability)
 
     -- Shaman
 
     [2645] = { type = BUFF_SPEED_BOOST, nounitFrames = true, nonameplates = true }, -- Ghost Wolf
-    [2825] = { type = BUFF_OFFENSIVE }, -- Bloodlust
-        [32182] = { type = BUFF_OFFENSIVE, parent = 2825 }, -- Heroism
-    [8178] = { type = IMMUNITY_SPELL }, -- Grounding Totem
+    [8178] = { type = IMMUNITY_SPELL }, -- Grounding Totem Effect (PvP Talent)
+    [208997] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Counterstrike Totem (PvP Talent)
     [51514] = { type = CROWD_CONTROL }, -- Hex
-        [196932] = { type = CROWD_CONTROL, parent = 51514 }, -- Voodoo Totem
         [210873] = { type = CROWD_CONTROL, parent = 51514 }, -- Hex (Compy)
         [211004] = { type = CROWD_CONTROL, parent = 51514 }, -- Hex (Spider)
         [211010] = { type = CROWD_CONTROL, parent = 51514 }, -- Hex (Snake)
@@ -461,29 +467,32 @@ addon.Spells = {
     [325174] = { type = BUFF_DEFENSIVE }, -- Spirit Link Totem
         [204293] = { type = BUFF_DEFENSIVE, parent = 325174 }, -- Spirit Link (PvP Talent)
     [108271] = { type = BUFF_DEFENSIVE }, -- Astral Shift
-        [210918] = { type = BUFF_DEFENSIVE, parent = 108271 }, -- Ethereal Form
+        [210918] = { type = BUFF_DEFENSIVE, parent = 108271 }, -- Ethereal Form (Enhancement PvP Talent)
     [114049] = { type = BUFF_OFFENSIVE }, -- Ascendance
-        [114050] = { type = BUFF_DEFENSIVE, parent = 114049 }, -- Ascendance (Elemental)
+        [114050] = { type = BUFF_OFFENSIVE, parent = 114049 }, -- Ascendance (Elemental)
         [114051] = { type = BUFF_OFFENSIVE, parent = 114049 }, -- Ascendance (Enhancement)
         [114052] = { type = BUFF_DEFENSIVE, parent = 114049 }, -- Ascendance (Restoration)
     [118345] = { type = CROWD_CONTROL }, -- Pulverize
+    [118337] = { type = BUFF_DEFENSIVE }, -- Harden Skin
     [118905] = { type = CROWD_CONTROL }, -- Static Charge
     [191634] = { type = BUFF_OFFENSIVE }, -- Stormkeeper (Ele)
     [320137] = { type = BUFF_OFFENSIVE }, -- Stormkeeper (Enh)
     [197214] = { type = CROWD_CONTROL }, -- Sundering
     [201633] = { type = BUFF_DEFENSIVE }, -- Earthen Wall Totem
-    [204366] = { type = BUFF_OFFENSIVE }, -- Thundercharge
-    [204945] = { type = BUFF_OFFENSIVE }, -- Doom Winds
-    [260878] = { type = BUFF_DEFENSIVE }, -- Spirit Wolf
+    [204366] = { type = BUFF_OFFENSIVE }, -- Thundercharge (Enhancement PvP Talent)
+    [335903] = { type = BUFF_OFFENSIVE }, -- Doom Winds
+    [260881] = { type = BUFF_DEFENSIVE }, -- Spirit Wolf
     [290641] = { type = BUFF_DEFENSIVE }, -- Ancestral Gift
-    [305485] = { type = CROWD_CONTROL }, -- Lightning Lasso (Player)
-          [305484] = { type = CROWD_CONTROL, parent = 305485 }, -- Lightning Lasso (NPC)
+    [305485] = { type = CROWD_CONTROL }, -- Lightning Lasso (PvP Talent)
+          [305484] = { type = CROWD_CONTROL, parent = 305485 }, -- Lightning Lasso on stun-immune NPCs (PvP Talent)
     [320125] = { type = BUFF_OFFENSIVE }, -- Echoing Shock
     [546] = { type = BUFF_OTHER }, -- Water Walking
     [333957] = { type = BUFF_OFFENSIVE }, -- Feral Spirit
     [204361] = { type = BUFF_OFFENSIVE }, -- Bloodlust (Enhancement PvP Talent)
         [204362] = { type = BUFF_OFFENSIVE, parent = 204361 }, -- Heroism (Enhancement PvP Talent)
     [192082] = { type = BUFF_SPEED_BOOST }, -- Windrush Totem
+    [338036] = { type = BUFF_SPEED_BOOST }, -- Thunderous Paws (Conduit)
+    [327164] = { type = BUFF_OFFENSIVE }, -- Primordial Wave (Necrolord Ability)
 
     -- Warlock
 
@@ -494,26 +503,31 @@ addon.Spells = {
     [20707] = { type = BUFF_OTHER }, -- Soulstone
     [22703] = { type = CROWD_CONTROL }, -- Infernal Awakening
     [30283] = { type = CROWD_CONTROL }, -- Shadowfury
-    [89751] = { type = BUFF_OFFENSIVE }, -- Felstorm
     [89766] = { type = CROWD_CONTROL }, -- Axe Toss
     [104773] = { type = BUFF_DEFENSIVE }, -- Unending Resolve
     [108416] = { type = BUFF_DEFENSIVE }, -- Dark Pact
     [111400] = { type = BUFF_SPEED_BOOST }, -- Burning Rush
     [113860] = { type = BUFF_OFFENSIVE }, -- Dark Soul: Misery (Affliction)
     [113858] = { type = BUFF_OFFENSIVE }, -- Dark Soul: Instability (Destruction)
+    [265273] = { type = BUFF_OFFENSIVE }, -- Demonic Power (Demonic Tyrant)
     [118699] = { type = CROWD_CONTROL }, -- Fear
     [196364] = { type = CROWD_CONTROL }, -- Unstable Affliction (Silence)
-    [212295] = { type = IMMUNITY_SPELL }, -- Nether Ward
+    [212295] = { type = IMMUNITY_SPELL }, -- Nether Ward (PvP Talent)
     [1098] = { type = CROWD_CONTROL }, -- Subjugate Demon
     [234877] = { type = DEBUFF_OFFENSIVE }, -- Bane of Shadows (Affliction PvP Talent)
+    [316099] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Unstable Affliction
+        [342938] = { type = DEBUFF_OFFENSIVE, parent = 316099 }, -- Unstable Affliction (Affliction PvP Talent)
     [30213] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Legion Strike
-    [200587] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Fel Fissure
-    [212580] = { type = DEBUFF_OFFENSIVE }, -- Eye of the Observer
-    [221705] = { type = BUFF_DEFENSIVE }, -- Casting Circle
+    [200587] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Fel Fissure (PvP Talent)
+    [221705] = { type = BUFF_DEFENSIVE }, -- Casting Circle (PvP Talent)
     [333889] = { type = BUFF_DEFENSIVE }, -- Fel Domination
     [344566] = { type = BUFF_OFFENSIVE }, -- Rapid Contagion (Affliction PvP Talent)
     [267171] = { type = BUFF_OFFENSIVE }, -- Demonic Strength
     [267218] = { type = BUFF_OFFENSIVE }, -- Nether Portal
+    [80240] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Havoc
+        [200548] = { type = DEBUFF_OFFENSIVE, parent = 80240 }, -- Bane of Havoc (Destro PvP Talent)
+    [213688] = { type = CROWD_CONTROL }, -- Fel Cleave - Fel Lord stun (Demo PvP Talent)
+    [339412] = { type = BUFF_SPEED_BOOST }, -- Demonic Momentum (Conduit)
 
     -- Warrior
 
@@ -525,29 +539,35 @@ addon.Spells = {
     [12975] = { type = BUFF_DEFENSIVE }, -- Last Stand
     [18499] = { type = BUFF_OTHER }, -- Berserker Rage
     [23920] = { type = IMMUNITY_SPELL }, -- Spell Reflection
-        [330279] = { type = IMMUNITY_SPELL, parent = 23920 }, -- Overwatch (Intervene Reflect)
+        [330279] = { type = IMMUNITY_SPELL, parent = 23920 }, -- Overwatch (PvP Talent)
+        [335255] = { type = IMMUNITY_SPELL, parent = 23920 }, -- Spell Reflection (Misshapen Mirror Legendary)
     [132168] = { type = CROWD_CONTROL }, -- Shockwave
     [97463] = { type = BUFF_DEFENSIVE }, -- Rallying Cry
-    [105771] = { type = ROOT }, -- Charge (Warrior)
+    [105771] = { type = ROOT }, -- Charge
     [107574] = { type = BUFF_OFFENSIVE }, -- Avatar
     [118038] = { type = BUFF_DEFENSIVE }, -- Die by the Sword
     [132169] = { type = CROWD_CONTROL }, -- Storm Bolt
     [147833] = { type = BUFF_DEFENSIVE }, -- Intervene
     [184364] = { type = BUFF_DEFENSIVE }, -- Enraged Regeneration
     [197690] = { type = BUFF_DEFENSIVE }, -- Defensive Stance
-    [199261] = { type = BUFF_OFFENSIVE }, -- Death Wish
     [208086] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Colossus Smash
-    [213871] = { type = BUFF_DEFENSIVE }, -- Bodyguard
+    [213871] = { type = BUFF_DEFENSIVE }, -- Bodyguard (Prot PvP Talent)
     [227847] = { type = IMMUNITY }, -- Bladestorm (Arms)
         [46924] = { type = IMMUNITY, parent = 227847 }, -- Bladestorm (Fury)
-    [236077] = { type = CROWD_CONTROL }, -- Disarm
-        [236236] = { type = CROWD_CONTROL, parent = 236077 }, -- Disarm
-    [236273] = { type = CROWD_CONTROL }, -- Duel
-    [236321] = { type = BUFF_DEFENSIVE }, -- War Banner
+    [236077] = { type = CROWD_CONTROL }, -- Disarm (PvP Talent)
+    [199042] = { type = ROOT }, -- Thunderstruck (Prot PvP Talent)
+    [236273] = { type = CROWD_CONTROL }, -- Duel (Arms PvP Talent)
+    [236321] = { type = BUFF_DEFENSIVE }, -- War Banner (PvP Talent)
     [262228] = { type = BUFF_OFFENSIVE }, -- Deadly Calm
     [199085] = { type = CROWD_CONTROL }, -- Warpath (Prot PvP Talent)
-    [198817] = { type = BUFF_OFFENSIVE }, -- Sharpen Blade
-        [198819] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Mortal Strike when applied with Sharpen Blade (50% healing reduc)
+    [198817] = { type = BUFF_OFFENSIVE }, -- Sharpen Blade (Arms PvP Talent) - "next cast will..." buff
+    [198819] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Mortal Strike when applied with Sharpen Blade (50% healing reduc)
+    [202164] = { type = BUFF_SPEED_BOOST }, -- Bounding Stride
+    [325886] = { type = CROWD_CONTROL }, -- Ancient Aftershock (Night Fae Ability)
+        [326062] = { type = CROWD_CONTROL, parent = 325886 }, -- Ancient Aftershock (Night Fae Ability) - periodic
+    [307871] = { type = CROWD_CONTROL, nounitFrames = true, nonameplates = true }, -- Spear of Bastion (Kyrian Ability)
+    [324143] = { type = BUFF_OFFENSIVE }, -- Conqueror's Banner (Necrolord Ability) - on the warrior
+        [325862] = { type = BUFF_OFFENSIVE, parent = 324143 }, -- Conqueror's Banner (Necrolord Ability) - on others
 
     -- Other
 
@@ -563,11 +583,11 @@ addon.Spells = {
 
     [20549] = { type = CROWD_CONTROL }, -- War Stomp
     [107079] = { type = CROWD_CONTROL }, -- Quaking Palm
-    [255654] = { type = CROWD_CONTROL }, -- Bull Rush
+    [255723] = { type = CROWD_CONTROL }, -- Bull Rush
     [287712] = { type = CROWD_CONTROL }, -- Haymaker
     [256948] = { type = BUFF_OTHER }, -- Spatial Rift
     [65116] = { type = BUFF_DEFENSIVE }, -- Stoneform
-    [265221] = { type = BUFF_DEFENSIVE }, -- Fireblood
+    [273104] = { type = BUFF_DEFENSIVE }, -- Fireblood
     [58984] = { type = BUFF_DEFENSIVE }, -- Shadowmeld
 
     -- Shadowlands: Covenant/Soulbind
@@ -577,15 +597,16 @@ addon.Spells = {
     [323524] = { type = IMMUNITY }, -- Ultimate Form (Necrolord - Marileth Trait)
     [324263] = { type = CROWD_CONTROL }, -- Sulfuric Emission (Necrolord - Emeni Trait)
     [327140] = { type = BUFF_OTHER }, -- Forgeborne Reveries (Necrolord - Bonesmith Heirmir Trait)
-    [329776] = { type = BUFF_DEFENSIVE }, -- Ascendant Phial (Kyrian - Kleia Trait)
+    [330752] = { type = BUFF_DEFENSIVE }, -- Ascendant Phial (Kyrian - Kleia Trait)
     [331866] = { type = CROWD_CONTROL }, -- Agent of Chaos (Venthyr - Nadjia Trait)
-    [332505] = { type = BUFF_DEFENSIVE }, -- Soulsteel Clamps (Kyrian - Mikanikos Trait)
+    [332505] = { type = BUFF_OTHER }, -- Soulsteel Clamps (Kyrian - Mikanikos Trait)
+        [332506] = { type = BUFF_OTHER, parent = 332505 }, -- Soulsteel Clamps (Kyrian - Mikanikos Trait) - when moving
     [332423] = { type = CROWD_CONTROL }, -- Sparkling Driftglobe Core (Kyrian - Mikanikos Trait)
 
     -- Legacy (may be deprecated)
 
-    [305252] = { type = CROWD_CONTROL }, -- Gladiator's Maledict
-    [313148] = { type = CROWD_CONTROL }, -- Forbidden Obsidian Claw
+    --[305252] = { type = CROWD_CONTROL }, -- Gladiator's Maledict
+    --[313148] = { type = CROWD_CONTROL }, -- Forbidden Obsidian Claw
 
     -- Special
     --[6788] = { type = "special", nounitFrames = true, noraidFrames = true }, -- Weakened Soul


### PR DESCRIPTION
Hey, so I've been working on a spell update / polish. Most of the diffs are pretty straightforward, but here's a breakdown of the changes:

* Spell id corrections / removals were all tested (in some cases vs both players and npcs where I felt like I need to confirm that) and/or I've identified the reason they were wrong in the first place (some ids were linking to spells without auras - they were just the spell ids of the talents/spells themselves, not of the buffs/debuffs). Also removed some old spells that simply don't exist anymore.
* Added a bunch of stuff that I think is important, particularly a lot of Covenant abilities and some important Shadowlands Legendary effects were missing. I've been very careful with this however, since this addon only shows one thing at a time. In that vain, I've also changed the default setting for Mindgames to make it show up everywhere, since the spell is very important in current meta (and nothing will change in 9.1 in that regard).
* I've also removed a few things that I think simply aren't important enough:
  - A Guardian Druid simply dumps his rage into Ironfur rotationally, so it's going to be up the whole time you're fighting one (not to mention that it's pretty pointless to see it without seeing number of stacks, which we don't display). Same goes for Tigereye Brew - if WW monks play this talent, they just use it rotationally; same goes for Death Wish (which is also pointless to track without stacks) and Neurotoxin. I've removed all of these.
  - Tranquility no longer has a buff on the Resto Druid who's channeling it, the only buff it causes is just its little HoT effect on all targets affected, which I don't think is worth displaying.
  - Bursting Shot no longer disorients, just snares. We don't track snares, so I removed it.
  - Changed Symbols of Death defaults to be 'off' in all categories, since it's basically always going to be used together with Shadow Dance and it's better to see the latter. The spell itself is still in the list if someone wants to enable it and adjust its priority.
  - Removed the normal Felstorm for Demonology, it's used rotationally and doesn't do much. The one that can be considered a "go" is Demonic Strength.
  - Removing Exploding Keg since it only affects auto attacks.
  - I've removed all Bloodlusts - these can only be used in random bgs, and I just don't think that having 15-40 of these pop up on screen when the enemy team pops lust is useful at all, you can clearly hear it / see it anyway.
* I've also been checking what's going on in the in-game config menu:
  - In the case of Tree of Life, the buff that you gain when you press the cooldown is called "Incarnation" and it grants you access to ToL form. However, this buffs tooltip isn't informative at all and thus looks bad in the menu, so I've added the ToL spell id and then made the buffs spell id its child instead - now the menu entry for it is informative (it shows ToL tooltip).
  - I've also changed Dark Archangel for the same reason - the tooltip for the two buffs is exactly the same, so a user can't know the difference, he just sees a duplicate entry, which is ugly. Both the priest and the other targets gain the same effect anyway, so I've simply put it back to one being parent of the other.
  - I did the opposite for Binding Shot, where I split the root and the 'tether' aura, because the tooltips for that ARE different.
  - Also split Blessing of Sacrifice and Ultimate Sacrifice for the same reason. The tooltips are different and we can let users configure them separately.
* I've changed what we look at for Greater Invisibility. The way this spell works is when the Arcane Mage presses it, he gains two buffs - one for the invisibility itself, and one for 60% damage reduction that comes along with it (they're both called "Greater Invisibility"). The latter buff lingers for 3 seconds after the invisibility is broken, and thus can be used as a little defensive. I've pointed BigDebuffs to this 60% damage reduction buff instead, since that will effectively still make it show for the invisibility effect just as before, but also cover the 60% damage reduction portion.
* I'm proposing a change to the way Spirit of Redemption is tracked: ignore the "normal" effect, only show something for the "non-normal" ones. I think this is more intuitive - if BigDebuffs draws some kind of icon when you target the priest, he's gonna res / has the activate-able talent, if it doesn't show anything, then that's the "normal" SoR.
* I've added the ability to enable tracking of UA, VT, Soul Reaper, Counterstrike Totem (basically all the priority debuffs) to also be displayed on portraits/nameplates, with the defaults being 'off'. Mainly for consistency sake, since some of the priority debuffs had these options and some didn't. Same goes for "next cast will..." type of buffs.
* Commented out BFA trinkets. I think it's about time.

I realize we're very close to 9.1 release, but I already had more than half of the work for this done when the announcement was posted and decided to finish it anyway. I thought of waiting till 9.1 with this, but imho it's better to separate a 9.1 data update from what's just a polish/maintenance pass.