### PR TITLE
Added Ancestral Protection (Shaman Resurrection Totem)

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -494,6 +494,8 @@ addon.Spells = {
     [192082] = { type = BUFF_SPEED_BOOST }, -- Windrush Totem
     [338036] = { type = BUFF_SPEED_BOOST }, -- Thunderous Paws (Conduit)
     [327164] = { type = BUFF_OFFENSIVE }, -- Primordial Wave (Necrolord Ability)
+    [207495] = { type = BUFF_DEFENSIVE }, -- Ancestral Protection (Totem)
+    	[207498] = { type = BUFF_DEFENSIVE, parent = 207495 }, -- Ancestral Protection (Player)
 
     -- Warlock
 


### PR DESCRIPTION
A few times in arena a player would be resurrected out of no where and I'd be super confused.
This should help visualize when a res totem is out.