### PR TITLE
Fix combat nameplate anchor bug.

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -829,9 +829,10 @@ function BigDebuffs:AttachUnitFrame(unit)
 end
 
 function BigDebuffs:AttachNameplate(unit)
-	if InCombatLockdown() then return end
-
     local frame = self.Nameplates[unit]
+    if (not frame or frame:IsForbidden()) then
+        return
+    end
 
 	local config = self.db.profile.nameplates
 
@@ -1066,6 +1067,8 @@ end
 local pending = {}
 
 hooksecurefunc("CompactUnitFrame_UpdateAll", function(frame)
+    if not BigDebuffs.db.profile then return end
+    if not BigDebuffs.db.profile.raidFrames then return end
     if not BigDebuffs.db.profile.raidFrames.enabled then return end
     if frame:IsForbidden() then return end
     local name = frame:GetName()


### PR DESCRIPTION
There are no permissions concerns with nameplate anchors. Fix
a bug where anchoring to nameplates chooses the wrong anchor point
and gets stuck due to being in combat.