### PR TITLE
Use varargs unpacking instead of removed CompactUnitFrame_Util_IsBossAura

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1467,7 +1467,8 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 
         if not doneWithDebuffs then
             AuraUtil.ForEachAura(frame.displayedUnit, "HARMFUL", batchCount, function(...)
-                if CompactUnitFrame_Util_IsBossAura(...) then
+                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
+                if isBossAura then
                     if not bossDebuffs then
                         bossDebuffs = {};
                     end
@@ -1499,7 +1500,8 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
             index = 1;
             batchCount = math.max(frame.maxDebuffs, maxBuffs);
             AuraUtil.ForEachAura(frame.displayedUnit, "HELPFUL", batchCount, function(...)
-                if CompactUnitFrame_Util_IsBossAura(...) then
+                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
+                if isBossAura then
                     -- Boss Auras are considered Debuffs for our purposes.
                     if not doneWithDebuffs then
                         if not bossBuffs then
@@ -1545,8 +1547,9 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
             batchCount = math.max(frame.maxDebuffs, frame.maxDispelDebuffs);
             index = 1;
             AuraUtil.ForEachAura(frame.displayedUnit, "HARMFUL|RAID", batchCount, function(...)
+                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
                 if not doneWithDebuffs and displayOnlyDispellableDebuffs then
-                    if CompactUnitFrame_Util_ShouldDisplayDebuff(...) and not CompactUnitFrame_Util_IsBossAura(...) and not CompactUnitFrame_Util_IsPriorityDebuff(...) then
+                    if CompactUnitFrame_Util_ShouldDisplayDebuff(...) and not isBossAura and not CompactUnitFrame_Util_IsPriorityDebuff(...) then
                         if not nonBossDebuffs then
                             nonBossDebuffs = {};
                         end


### PR DESCRIPTION
Mirrors the API change from the previous patch: https://www.townlong-yak.com/framexml/42698/CompactUnitFrame.lua#1221
To live: https://www.townlong-yak.com/framexml/live/CompactUnitFrame.lua#1231

Per https://www.townlong-yak.com/framexml/42698/CompactUnitFrame.lua#1438 the deleted function was simply picking its 12th argument, so this change gives (most of) the enclosing function's arguments names, and then picks the 12th by name.

The only testing I've done for this is joined a party and made sure I could see >3 hots on myself.