### PR TITLE
Allow Ice Form to config separately from Icy Veins

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -253,7 +253,7 @@ addon.Spells = {
     [12042] = { type = BUFF_OFFENSIVE }, -- Arcane Power
     [12051] = { type = BUFF_OFFENSIVE }, -- Evocation
     [12472] = { type = BUFF_OFFENSIVE }, -- Icy Veins
-        [198144] = { type = BUFF_OFFENSIVE, parent = 12472 }, -- Ice Form
+        [198144] = { type = BUFF_OFFENSIVE }, -- Ice Form
     [31661] = { type = CROWD_CONTROL }, -- Dragon's Breath
     [45438] = { type = IMMUNITY }, -- Ice Block
     [41425] = { type = BUFF_OTHER }, -- Hypothermia


### PR DESCRIPTION
I know technically Ice Form should be parented to Icy Veins, but Icy Form does have a very unique functionality in addition to the damage portion: stun immunity.

By removing the parent, we can allow players to config Ice Form and Icy Veins separately, e.g., someone just wants to see the stun immunity on nameplates so he doesn't might bash / HOJ into it.