### PR TITLE
Spell update to priest resurrection legendary

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -389,7 +389,8 @@ addon.Spells = {
     [213610] = { type = BUFF_DEFENSIVE }, -- Holy Ward
     --[27827] = { type = BUFF_DEFENSIVE }, -- Spirit of Redemption
     [215769] = { type = BUFF_DEFENSIVE }, -- Spirit of Redemption (Spirit of the Redeemer Holy PvP Talent)
-    [211336] = { type = BUFF_DEFENSIVE }, -- Archbishop Benedictus' Restitution (Holy Priest Revive Legendary)
+    [211336] = { type = BUFF_DEFENSIVE }, -- Archbishop Benedictus' Restitution (Resurrection Buff)
+    [211319] = { type = BUFF_DEFENSIVE }, -- Archbishop Benedictus' Restitution (Debuff)
     [289655] = { type = BUFF_DEFENSIVE }, -- Holy Word: Concentration
     [319952] = { type = BUFF_OFFENSIVE }, -- Surrender to Madness
     [322431] = { type = BUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Thoughtsteal (Buff)


### PR DESCRIPTION
Added the cooldown debuff because the resurrection buff portion does not proc unless the priest heals a party member. Would sometimes get tricked by priest not healing and not having the buff portion pop up on plate.