### PR TITLE
Added sepsis debuff to rogue list

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -451,6 +451,7 @@ addon.Spells = {
     [340094] = { type = BUFF_OFFENSIVE }, -- Master Assassin's Mark (Legendary)
     [345569] = { type = BUFF_OFFENSIVE }, -- Flagellation (Venthyr Ability)
     [347037] = { type = BUFF_OFFENSIVE }, -- Sepsis (Night Fae Ability)
+    [347037] = { type = DEBUFF_OFFENSIVE, priority = true}, -- Sepsis (Night Fae Ability)
 
     -- Shaman
 

--- a/Retail.lua
+++ b/Retail.lua
@@ -451,7 +451,7 @@ addon.Spells = {
     [340094] = { type = BUFF_OFFENSIVE }, -- Master Assassin's Mark (Legendary)
     [345569] = { type = BUFF_OFFENSIVE }, -- Flagellation (Venthyr Ability)
     [347037] = { type = BUFF_OFFENSIVE }, -- Sepsis (Night Fae Ability)
-    [347037] = { type = DEBUFF_OFFENSIVE, priority = true}, -- Sepsis (Night Fae Ability)
+    [328305] = { type = DEBUFF_OFFENSIVE, priority = true}, -- Sepsis (Night Fae Ability)
 
     -- Shaman
 


### PR DESCRIPTION
The nightfae rogue ability Sepsis has two different components [- a debuff on a target](https://www.wowhead.com/spell=328305/sepsis) and a [buff ](https://www.wowhead.com/spell=347037/sepsis)that the rogue gets when sepsis expires. [Source](https://www.wowhead.com/spell=328305/sepsis#comments:id=3283904)

Added the debuff to the rogue list of offensive debuffs. 