### PR TITLE
Add Explosive Shot offensive debuff

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -234,6 +234,7 @@ addon.Spells = {
     [202748] = { type = BUFF_DEFENSIVE }, -- Survival Tactics (PvP Talent)
     [248519] = { type = IMMUNITY_SPELL }, -- Interlope (BM PvP Talent)
     [356727] = { type = CROWD_CONTROL }, -- Spider Venom of Chimaeral Sting (Hunter PvP Talent)
+    [212431] = { type = DEBUFF_OFFENSIVE }, -- Explosive Shot
 
     -- Mage
 


### PR DESCRIPTION
This pull requests adds the dispellable Explosive Shot debuff from hunters' necrolord legendary.