### PR TITLE
adding major feral bleeds

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -194,6 +194,8 @@ addon.Spells = {
     [338142] = { type = BUFF_OFFENSIVE }, -- Lone Empowerment (Kyrian Ability)
     [327037] = { type = BUFF_DEFENSIVE }, -- Kindred Protection (Kyrian Ability)
     [362486] = { type = IMMUNITY }, -- Keeper of the Grove
+    [274837] = { type = DEBUFF_OFFENSIVE }, -- Feral Frenzy
+    [363498] = { type = DEBUFF_OFFENSIVE }, -- Sickle of the Lion
 
     -- Hunter
 


### PR DESCRIPTION
Adding major feral bleeds.  Currently bleeds can be dispelled by hunters as well as the Kyrian potion. 

Verified by making changes to local and testing that the bleeds show up in raid frames.