### PR TITLE
wotlk talent fixes

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1066,8 +1066,7 @@ function BigDebuffs:COMBAT_LOG_EVENT_UNFILTERED()
                     if improvedConcAuraRank > 0 and UnitBuffByName(unit, "Concentration Aura") then
                         duration = duration * (1.0 - 0.1 * improvedConcAuraRank)
                     end
-                end
-                if playerClass == "SHAMAN" then
+                elseif playerClass == "SHAMAN" then
                     local focusedMindRank = select(5, GetTalentInfo(3, 14))
                     if focusedMindRank > 0 then
                         duration = duration * (1.0 - 0.1 * focusedMindRank)
@@ -1080,8 +1079,7 @@ function BigDebuffs:COMBAT_LOG_EVENT_UNFILTERED()
                     if improvedConcAuraRank > 0 and UnitBuffByName(unit, "Concentration Aura") then
                         duration = duration * (1.0 - 0.1 * improvedConcAuraRank)
                     end
-                end
-                if playerClass == "SHAMAN" then
+                elseif playerClass == "SHAMAN" then
                     local focusedMindRank = select(5, GetTalentInfo(3, 16))
                     if focusedMindRank > 0 then
                         duration = duration * (1.0 - 0.1 * focusedMindRank)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1073,6 +1073,20 @@ function BigDebuffs:COMBAT_LOG_EVENT_UNFILTERED()
                         duration = duration * (1.0 - 0.1 * focusedMindRank)
                     end
                 end
+            elseif WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC then
+                local _, playerClass = UnitClass("player")
+                if playerClass == "PALADIN" then
+                    local improvedConcAuraRank = select(5, GetTalentInfo(1, 8))
+                    if improvedConcAuraRank > 0 and UnitBuffByName(unit, "Concentration Aura") then
+                        duration = duration * (1.0 - 0.1 * improvedConcAuraRank)
+                    end
+                end
+                if playerClass == "SHAMAN" then
+                    local focusedMindRank = select(5, GetTalentInfo(3, 16))
+                    if focusedMindRank > 0 then
+                        duration = duration * (1.0 - 0.1 * focusedMindRank)
+                    end
+                end
             end
 
             self.units[destGUID] = self.units[destGUID] or {}


### PR DESCRIPTION
- paladin improved concentration aura
- shaman focused mind

for some reason the talentIndex for GetTalentInfo is not counted top-down left-right anymore, so that's why the values seem out-of-place, but tested to work (unlike #406 , where I just assumed it works like it used to)