### PR TITLE
Protected access errors

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1197,6 +1197,13 @@ hooksecurefunc("CompactUnitFrame_UpdateAll", function(frame)
     if frame:IsForbidden() then return end
     local name = frame:GetName()
     if not name or not name:match("^Compact") then return end
+
+    --catches very rare frame:SetAttribute() error when frame is not visible yet
+    if InCombatLockdown() and not frame:IsVisible() then
+        if not pending[frame] then pending[frame] = true end
+        return
+    end
+
     if InCombatLockdown() and not frame.BigDebuffs then
         if not pending[frame] then pending[frame] = true end
     else

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1197,6 +1197,7 @@ hooksecurefunc("CompactUnitFrame_UpdateAll", function(frame)
     if frame:IsForbidden() then return end
     local name = frame:GetName()
     if not name or not name:match("^Compact") then return end
+    if not frame.unit or not frame.unitExists then return end
 
     --catches very rare frame:SetAttribute() error when frame is not visible yet
     if InCombatLockdown() and not frame:IsVisible() then


### PR DESCRIPTION
#411 has additional information.
The proposed frame:SetAttribute() error code can be refactored into the code block directly below it, but leaving out for now for easier testing.