### PR TITLE
updates to support dragon flight

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -681,6 +681,23 @@ local anchors = {
             arena5 = "ArenaEnemyFrame5ClassPortrait",
         },
     },
+    ["BlizzardRetail"] = {
+        units = {
+            player = "PlayerFrame",
+            pet = "PetPortrait",
+            target = "TargetFrame",
+            focus = "FocusFrame",
+            --party1 = "PartyMemberFrame1Portrait",
+            --party2 = "PartyMemberFrame2Portrait",
+            --party3 = "PartyMemberFrame3Portrait",
+            --party4 = "PartyMemberFrame4Portrait",
+            arena1 = "ArenaEnemyMatchFrame1ClassPortrait",
+            arena2 = "ArenaEnemyMatchFrame2ClassPortrait",
+            arena3 = "ArenaEnemyMatchFrame3ClassPortrait",
+            arena4 = "ArenaEnemyMatchFrame4ClassPortrait",
+            arena5 = "ArenaEnemyMatchFrame5ClassPortrait",
+        },
+    },
 }
 
 BigDebuffs.anchors = anchors
@@ -789,6 +806,13 @@ end
 function BigDebuffs:AttachUnitFrame(unit)
     if InCombatLockdown() then return end
 
+    --remove this once a better way to attach frame to new party container introduced in 10.0
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+        if (unit == "party1" or unit == "party2" or unit == "party3" or unit == "party4") then
+            return
+        end
+    end
+
     local frame = self.UnitFrames[unit]
     local frameName = addonName .. unit .. "UnitFrame"
 
@@ -805,7 +829,7 @@ function BigDebuffs:AttachUnitFrame(unit)
         end
         frame.cooldown:SetHideCountdownNumbers(not self.db.profile.unitFrames.cooldownCount)
         frame.cooldown.noCooldownCount = not self.db.profile.unitFrames.cooldownCount
-        frame.icon:SetDrawLayer("BORDER")
+        --frame.icon:SetDrawLayer("BORDER")
         frame:RegisterUnitEvent("UNIT_AURA", unit)
         frame:RegisterForDrag("LeftButton")
         frame:SetMovable(true)
@@ -814,7 +838,9 @@ function BigDebuffs:AttachUnitFrame(unit)
 
     frame:EnableMouse(self.test)
 
-    _G[frameName.."Name"]:SetText(self.test and not frame.anchor and unit)
+    if self.test and not frame.anchor and unit then
+        _G[frameName.."Name"]:SetText(unit)
+    end
 
     frame.anchor = nil
     frame.blizzard = nil
@@ -829,14 +855,36 @@ function BigDebuffs:AttachUnitFrame(unit)
                 if v.func then
                     anchor, parent, noPortait = v.func(v.units[unit])
                 else
-                    anchor = _G[v.units[unit]]
+                    --portraits moved to container in 10.0, not sure how else to handle these containers right now
+                    if k == "BlizzardRetail" and (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE) then
+                        if unit == "player" then
+                            anchor = _G[v.units[unit]].PlayerFrameContainer.PlayerPortrait
+                        elseif unit == "target" or unit == "focus" then
+                            anchor = _G[v.units[unit]].TargetFrameContainer.Portrait
+                        --elseif unit == "party1" or unit == "party2" or unit == "party3" or unit == "party4" then
+                            --for memberFrame in _G["PartyFrame"].PartyMemberFramePool:EnumerateActive() do
+                                --local partyUnit = memberFrame:GetUnit()
+                                --if partyUnit and UnitGUID(partyUnit) and UnitIsPlayer(partyUnit) and unit == partyUnit then
+                                --if partyUnit and UnitGUID(partyUnit) and UnitIsPlayer(partyUnit) then
+                                    --anchor = memberFrame
+                                --end
+                            --end
+                        else
+                            --arena[1-5] and pet
+                            anchor = _G[v.units[unit]]
+                        end
+                    elseif k == "BlizzardRetail" then
+                        break
+                    else
+                        anchor = _G[v.units[unit]]
+                    end
                 end
 
                 if anchor then
                     frame.anchor, frame.parent, frame.noPortait = anchor, parent, noPortait
                     if v.noPortait then frame.noPortait = true end
                     frame.alignLeft = v.alignLeft
-                    frame.blizzard = (k == "Blizzard" or k == "sArena")
+                    frame.blizzard = (k == "Blizzard" or k == "sArena" or k == "BlizzardRetail")
                     if not frame.blizzard then break end
                 end
             end
@@ -850,6 +898,11 @@ function BigDebuffs:AttachUnitFrame(unit)
             frame:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel())
             frame.cooldown:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel())
             frame.anchor:SetDrawLayer("BACKGROUND")
+
+            frame:SetScale(1.2)
+            --frame.IconMask:Show()
+            frame.NormalTexture:Hide()
+
             frame.cooldown:SetSwipeTexture("Interface\\CHARACTERFRAME\\TempPortraitAlphaMaskSmall")
         else
             frame:SetParent(frame.parent and frame.parent or frame.anchor)
@@ -1359,6 +1412,45 @@ if LibClassicDurations then
     end)
 end
 
+--update 10.0
+local function CompactUnitFrame_UtilSetDebuff_Retail(debuffFrame, aura)
+    --print("in new util thing")
+    debuffFrame.filter = aura.isRaid and AuraUtil.AuraFilters.Raid;
+    debuffFrame.icon:SetTexture(aura.icon);
+    if ( aura.applications > 1 ) then
+        local countText = aura.applications;
+        if ( aura.applications >= 100 ) then
+            countText = BUFF_STACKS_OVERFLOW;
+        end
+        debuffFrame.count:Show();
+        debuffFrame.count:SetText(countText);
+    else
+        debuffFrame.count:Hide();
+    end
+    debuffFrame.auraInstanceID = aura.auraInstanceID;
+    local enabled = aura.expirationTime and aura.expirationTime ~= 0;
+    if enabled then
+        local startTime = aura.expirationTime - aura.duration;
+        CooldownFrame_Set(debuffFrame.cooldown, startTime, aura.duration, true);
+    else
+        CooldownFrame_Clear(debuffFrame.cooldown);
+    end
+
+    local color = DebuffTypeColor[aura.dispelName] or DebuffTypeColor["none"];
+    debuffFrame.border:SetVertexColor(color.r, color.g, color.b);
+
+    debuffFrame.isBossBuff = aura.isBossAura and aura.isHelpful;
+    if ( aura.isBossAura ) then
+        local size = min(debuffFrame.baseSize + BOSS_DEBUFF_SIZE_INCREASE, debuffFrame.maxHeight);
+        debuffFrame:SetSize(size, size);
+    else
+        debuffFrame:SetSize(debuffFrame.baseSize, debuffFrame.baseSize);
+    end
+
+    debuffFrame:Show();
+end
+
+--classic and BigDebuffs:ShowBigDebuffs()
 local function CompactUnitFrame_UtilSetDebuff(debuffFrame, unit, index, filter, isBossAura, isBossBuff, ...)
     local UnitDebuff = BigDebuffs.test and UnitDebuffTest or UnitDebuff
     -- make sure you are using the correct index here!
@@ -1442,68 +1534,39 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
         return BigDebuffs:IsPriorityBigDebuff(spellId) or Default_CompactUnitFrame_Util_IsPriorityDebuff(spellId)
     end
 
-    local function SetDebuffsHelper(debuffFrames, frameNum, maxDebuffs, filter, isBossAura, isBossBuff, auras)
-        if auras then
-            for i = 1,#auras do
-                local aura = auras[i];
-                if frameNum > maxDebuffs then
-                    break;
-                end
-                local debuffFrame = debuffFrames[frameNum];
-                local index, name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, nameplateShowPersonal, spellId = aura[1], aura[2], aura[3], aura[4], aura[5], aura[6], aura[7], aura[8], aura[9], aura[10], aura[11];
-                local unit = nil;
-                CompactUnitFrame_UtilSetDebuff(debuffFrame, unit, index, filter, isBossAura, isBossBuff, name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, nameplateShowPersonal, spellId);
-                frameNum = frameNum + 1;
-
-                if isBossAura then
-                    --Boss auras are about twice as big as normal debuffs, so we may need to display fewer buffs
-                    local bossDebuffScale = (debuffFrame.baseSize + BOSS_DEBUFF_SIZE_INCREASE)/debuffFrame.baseSize;
-                    maxDebuffs = maxDebuffs - (bossDebuffScale - 1);
-                end
+    local function CompactUnitFrame_ParseAllAuras(frame, displayOnlyDispellableDebuffs, ignoreBuffs, ignoreDebuffs, ignoreDispelDebuffs)
+        if frame.debuffs == nil then
+            frame.debuffs = TableUtil.CreatePriorityTable(AuraUtil.UnitFrameDebuffComparator, TableUtil.Constants.AssociativePriorityTable);
+            frame.buffs = TableUtil.CreatePriorityTable(AuraUtil.DefaultAuraCompare, TableUtil.Constants.AssociativePriorityTable);
+            frame.dispels = {};
+            for type, _ in pairs(AuraUtil.DispellableDebuffTypes) do
+                frame.dispels[type] = TableUtil.CreatePriorityTable(AuraUtil.DefaultAuraCompare, TableUtil.Constants.AssociativePriorityTable);
+            end
+        else
+            frame.debuffs:Clear();
+            frame.buffs:Clear();
+            for type, _ in pairs(AuraUtil.DispellableDebuffTypes) do
+                frame.dispels[type]:Clear();
             end
         end
-        return frameNum, maxDebuffs;
-    end
 
-    local function NumElements(arr)
-        return arr and #arr or 0;
-    end
+        local batchCount = nil;
+        local usePackedAura = true;
+        local function HandleAura(aura)
+            local type = AuraUtil.ProcessAura(aura, displayOnlyDispellableDebuffs, ignoreBuffs, ignoreDebuffs, ignoreDispelDebuffs);
 
-    local dispellableDebuffTypes = { Magic = true, Curse = true, Disease = true, Poison = true};
-
-    local function CompactUnitFrame_CouldDisplayAura(auraInfo, ...)
-        local displayOnlyDispellableDebuffs = ...;
-
-        if auraInfo.isNameplateOnly then
-            return false;
+            if type == AuraUtil.AuraUpdateChangedType.Debuff then
+                frame.debuffs[aura.auraInstanceID] = aura;
+            elseif type == AuraUtil.AuraUpdateChangedType.Buff then
+                frame.buffs[aura.auraInstanceID] = aura;
+            elseif type == AuraUtil.AuraUpdateChangedType.Dispel then
+                frame.debuffs[aura.auraInstanceID] = aura;
+                frame.dispels[aura.dispelName][aura.auraInstanceID] = aura;
+            end
         end
-
-        if auraInfo.isBossAura then
-            return true;
-        end
-
-        if auraInfo.isHarmful and CompactUnitFrame_Util_IsPriorityDebuff(auraInfo.spellId) then
-            return true;
-        end
-
-        if auraInfo.isHarmful and (not displayOnlyDispellableDebuffs) and CompactUnitFrame_Util_ShouldDisplayDebuff(auraInfo.sourceUnit, auraInfo.spellId) then
-            return true;
-        end
-
-        if auraInfo.isHelpful and CompactUnitFrame_UtilShouldDisplayBuff(auraInfo.sourceUnit, auraInfo.spellId, auraInfo.canApplyAura) then
-            return true;
-        end
-
-        local isHarmfulAndRaid = auraInfo.isHarmful and auraInfo.isRaid;
-        if isHarmfulAndRaid and (not auraInfo.isBossAura) and displayOnlyDispellableDebuffs and CompactUnitFrame_Util_ShouldDisplayDebuff(auraInfo.sourceUnit, auraInfo.spellId) and (not CompactUnitFrame_Util_IsPriorityDebuff(auraInfo.spellId)) then
-            return true;
-        end
-
-        if isHarmfulAndRaid and dispellableDebuffTypes[auraInfo.debuffType] ~= nil then
-            return true;
-        end
-
-        return false;
+        AuraUtil.ForEachAura(frame.displayedUnit, AuraUtil.CreateFilterString(AuraUtil.AuraFilters.Harmful), batchCount, HandleAura, usePackedAura);
+        AuraUtil.ForEachAura(frame.displayedUnit, AuraUtil.CreateFilterString(AuraUtil.AuraFilters.Helpful), batchCount, HandleAura, usePackedAura);
+        AuraUtil.ForEachAura(frame.displayedUnit, AuraUtil.CreateFilterString(AuraUtil.AuraFilters.Harmful, AuraUtil.AuraFilters.Raid), batchCount, HandleAura, usePackedAura);
     end
 
     hooksecurefunc("CompactUnitFrame_UpdateAuras", function(frame, isFullUpdate, updatedAuraInfos)
@@ -1513,168 +1576,144 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
         if (not UnitIsPlayer(frame.displayedUnit)) then return end
 
         local displayOnlyDispellableDebuffs = frame.optionTable.displayOnlyDispellableDebuffs;
+        local ignoreBuffs = not frame.buffFrames or not frame.optionTable.displayBuffs or frame.maxBuffs == 0;
+        local ignoreDebuffs = not frame.debuffFrames or not frame.optionTable.displayDebuffs or frame.maxDebuffs == 0;
+        local ignoreDispelDebuffs = ignoreDebuffs or not frame.dispelDebuffFrames or not frame.optionTable.displayDispelDebuffs or frame.maxDispelDebuffs == 0;
 
-        -- if AuraUtil.ShouldSkipAuraUpdate(isFullUpdate, updatedAuraInfos, CompactUnitFrame_CouldDisplayAura, displayOnlyDispellableDebuffs) then
-        --     return;
-        -- end
+        local debuffsChanged = false;
+        local buffsChanged = false;
+        local dispelsChanged = false;
 
-        local doneWithBuffs = not frame.buffFrames or not frame.optionTable.displayBuffs or frame.maxBuffs == 0;
-        local doneWithDebuffs = not frame.debuffFrames or not frame.optionTable.displayDebuffs or frame.maxDebuffs == 0;
-        local doneWithDispelDebuffs = not frame.dispelDebuffFrames or not frame.optionTable.displayDispelDebuffs or frame.maxDispelDebuffs == 0;
-
-        local numUsedBuffs = 0;
-        local numUsedDebuffs = 0;
-        local numUsedDispelDebuffs = 0;
-
-        -- The following is the priority order for debuffs
-        local bossDebuffs, bossBuffs, priorityDebuffs, nonBossDebuffs, nonBossRaidDebuffs;
-        local index = 1;
-        local batchCount = frame.maxDebuffs;
-
-        if not doneWithDebuffs then
-            AuraUtil.ForEachAura(frame.displayedUnit, "HARMFUL", batchCount, function(...)
-                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
-                if isBossAura then
-                    if not bossDebuffs then
-                        bossDebuffs = {};
-                    end
-                    tinsert(bossDebuffs, {index, ...});
-                    numUsedDebuffs = numUsedDebuffs + 1;
-                    if numUsedDebuffs == frame.maxDebuffs then
-                        doneWithDebuffs = true;
-                        return true;
-                    end
-                elseif CompactUnitFrame_Util_IsPriorityDebuff(spellId) then
-                    if not priorityDebuffs then
-                        priorityDebuffs = {};
-                    end
-                    tinsert(priorityDebuffs, {index, ...});
-                elseif not displayOnlyDispellableDebuffs and CompactUnitFrame_Util_ShouldDisplayDebuff(unitCaster, spellId) then
-                    if not nonBossDebuffs then
-                        nonBossDebuffs = {};
-                    end
-                    tinsert(nonBossDebuffs, {index, ...});
-                end
-
-                index = index + 1;
-                return false;
-            end);
-        end
-
-        if not doneWithBuffs or not doneWithDebuffs then
-            local maxBuffs = BigDebuffs.db.profile.raidFrames.increaseBuffs and MAX_BUFFS or frame.maxBuffs
-            index = 1;
-            batchCount = math.max(frame.maxDebuffs, maxBuffs);
-            AuraUtil.ForEachAura(frame.displayedUnit, "HELPFUL", batchCount, function(...)
-                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
-                if isBossAura then
-                    -- Boss Auras are considered Debuffs for our purposes.
-                    if not doneWithDebuffs then
-                        if not bossBuffs then
-                            bossBuffs = {};
-                        end
-                        tinsert(bossBuffs, {index, ...});
-                        numUsedDebuffs = numUsedDebuffs + 1;
-                        if numUsedDebuffs == frame.maxDebuffs then
-                            doneWithDebuffs = true;
-                        end
-                    end
-                elseif CompactUnitFrame_UtilShouldDisplayBuff(unitCaster, spellId, canApplyAura) then
-                    if not doneWithBuffs then
-                        numUsedBuffs = numUsedBuffs + 1;
-                        local buffFrame = frame.buffFrames[numUsedBuffs];
-                        CompactUnitFrame_UtilSetBuff(buffFrame, index, ...);
-                        if numUsedBuffs == maxBuffs then
-                            doneWithBuffs = true;
-                        end
+        if unitAuraUpdateInfo == nil or unitAuraUpdateInfo.isFullUpdate or frame.debuffs == nil then
+            CompactUnitFrame_ParseAllAuras(frame, displayOnlyDispellableDebuffs, ignoreBuffs, ignoreDebuffs, ignoreDispelDebuffs);
+            debuffsChanged = true;
+            buffsChanged = true;
+            dispelsChanged = true;
+        else
+            if unitAuraUpdateInfo.addedAuras ~= nil then
+                for _, aura in ipairs(unitAuraUpdateInfo.addedAuras) do
+                    local type = AuraUtil.ProcessAura(aura, displayOnlyDispellableDebuffs, ignoreBuffs, ignoreDebuffs, ignoreDispelDebuffs);
+                    if type == AuraUtil.AuraUpdateChangedType.Debuff then
+                        frame.debuffs[aura.auraInstanceID] = aura;
+                        debuffsChanged = true;
+                    elseif type == AuraUtil.AuraUpdateChangedType.Buff then
+                        frame.buffs[aura.auraInstanceID] = aura;
+                        buffsChanged = true;
+                    elseif type == AuraUtil.AuraUpdateChangedType.Dispel then
+                        frame.debuffs[aura.auraInstanceID] = aura;
+                        debuffsChanged = true;
+                        frame.dispels[aura.dispelName][aura.auraInstanceID] = aura;
+                        dispelsChanged = true;
                     end
                 end
+            end
 
-                index = index + 1;
-                return doneWithBuffs and doneWithDebuffs;
-            end);
-        end
+            if unitAuraUpdateInfo.updatedAuraInstanceIDs ~= nil then
+                for _, auraInstanceID in ipairs(unitAuraUpdateInfo.updatedAuraInstanceIDs) do
+                    if frame.debuffs[auraInstanceID] ~= nil then
+                        local newAura = C_UnitAuras.GetAuraDataByAuraInstanceID(frame.displayedUnit, auraInstanceID);
+                        local oldDebuffType = frame.debuffs[auraInstanceID].debuffType;
+                        if newAura ~= nil then
+                            newAura.debuffType = oldDebuffType;
+                        end
+                        frame.debuffs[auraInstanceID] = newAura;
+                        debuffsChanged = true;
 
-        numUsedDebuffs = math.min(frame.maxDebuffs, numUsedDebuffs + NumElements(priorityDebuffs));
-        if numUsedDebuffs == frame.maxDebuffs then
-            doneWithDebuffs = true;
-        end
+                        for _, tbl in pairs(frame.dispels) do
+                            if tbl[auraInstanceID] ~= nil then
+                                tbl[auraInstanceID] = C_UnitAuras.GetAuraDataByAuraInstanceID(frame.displayedUnit, auraInstanceID);
+                                dispelsChanged = true;
+                                break;
+                            end
+                        end
+                    elseif frame.buffs[auraInstanceID] ~= nil then
+                        local newAura = C_UnitAuras.GetAuraDataByAuraInstanceID(frame.displayedUnit, auraInstanceID);
+                        if newAura ~= nil then
+                            newAura.isBuff = true;
+                        end
+                        frame.buffs[auraInstanceID] = newAura;
+                        buffsChanged = true;
+                    end
+                end
+            end
 
-        if not doneWithDispelDebuffs then
-            --Clear what we currently have for dispellable debuffs
-            for debuffType, display in pairs(dispellableDebuffTypes) do
-                if ( display ) then
-                    frame["hasDispel"..debuffType] = false;
+            if unitAuraUpdateInfo.removedAuraInstanceIDs ~= nil then
+                for _, auraInstanceID in ipairs(unitAuraUpdateInfo.removedAuraInstanceIDs) do
+                    if frame.debuffs[auraInstanceID] ~= nil then
+                        frame.debuffs[auraInstanceID] = nil;
+                        debuffsChanged = true;
+
+                        for _, tbl in pairs(frame.dispels) do
+                            if tbl[auraInstanceID] ~= nil then
+                                tbl[auraInstanceID] = nil;
+                                dispelsChanged = true;
+                                break;
+                            end
+                        end
+                    elseif frame.buffs[auraInstanceID] ~= nil then
+                        frame.buffs[auraInstanceID] = nil;
+                        buffsChanged = true;
+                    end
                 end
             end
         end
 
-        if not doneWithDispelDebuffs or not doneWithDebuffs then
-            batchCount = math.max(frame.maxDebuffs, frame.maxDispelDebuffs);
-            index = 1;
-            AuraUtil.ForEachAura(frame.displayedUnit, "HARMFUL|RAID", batchCount, function(...)
-                local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura, isBossAura = ...;
-                if not doneWithDebuffs and displayOnlyDispellableDebuffs then
-                    if CompactUnitFrame_Util_ShouldDisplayDebuff(unitCaster, spellId) and not isBossAura and not CompactUnitFrame_Util_IsPriorityDebuff(spellId) then
-                        if not nonBossRaidDebuffs then
-                            nonBossRaidDebuffs = {};
-                        end
-                        tinsert(nonBossRaidDebuffs, {index, ...});
-                        numUsedDebuffs = numUsedDebuffs + 1;
-                        if numUsedDebuffs == frame.maxDebuffs then
-                            doneWithDebuffs = true;
-                        end
-                    end
+        if debuffsChanged then
+            local frameNum = 1;
+            local maxDebuffs = frame.maxDebuffs;
+            frame.debuffs:Iterate(function(auraInstanceID, aura)
+                if frameNum > maxDebuffs then
+                    return true;
                 end
-                if not doneWithDispelDebuffs then
-                    if ( dispellableDebuffTypes[debuffType] and not frame["hasDispel"..debuffType] ) then
-                        frame["hasDispel"..debuffType] = true;
-                        numUsedDispelDebuffs = numUsedDispelDebuffs + 1;
-                        local dispellDebuffFrame = frame.dispelDebuffFrames[numUsedDispelDebuffs];
-                        CompactUnitFrame_UtilSetDispelDebuff(dispellDebuffFrame, debuffType, index)
-                        if numUsedDispelDebuffs == frame.maxDispelDebuffs then
-                            doneWithDispelDebuffs = true;
-                        end
-                    end
+                local debuffFrame = frame.debuffFrames[frameNum];
+                CompactUnitFrame_UtilSetDebuff_Retail(debuffFrame, aura);
+                frameNum = frameNum + 1;
+
+                if aura.isBossAura then
+                    -- Boss auras are about twice as big as normal debuffs, so we may need to display fewer buffs
+                    local bossDebuffScale = (debuffFrame.baseSize + BOSS_DEBUFF_SIZE_INCREASE)/debuffFrame.baseSize;
+                    maxDebuffs = maxDebuffs - (bossDebuffScale - 1);
                 end
-                index = index + 1;
-                return (doneWithDebuffs or not displayOnlyDispellableDebuffs) and doneWithDispelDebuffs;
+
+                return false;
             end);
+
+            CompactUnitFrame_HideAllDebuffs(frame, frameNum);
         end
 
-        local frameNum = 1;
-        local maxDebuffs = frame.maxDebuffs;
+        if buffsChanged then
+            local frameNum = 1;
+            local maxBuffs = frame.maxBuffs;
+            frame.buffs:Iterate(function(auraInstanceID, aura)
+                if frameNum > maxBuffs then
+                    return true;
+                end
+                local buffFrame = frame.buffFrames[frameNum];
+                CompactUnitFrame_UtilSetBuff(buffFrame, aura);
+                frameNum = frameNum + 1;
 
-        do
-            local isBossAura = true;
-            local isBossBuff = false;
-            frameNum, maxDebuffs = SetDebuffsHelper(frame.debuffFrames, frameNum, maxDebuffs, "HARMFUL", isBossAura, isBossBuff, bossDebuffs);
-        end
-        do
-            local isBossAura = true;
-            local isBossBuff = true;
-            frameNum, maxDebuffs = SetDebuffsHelper(frame.debuffFrames, frameNum, maxDebuffs, "HELPFUL", isBossAura, isBossBuff, bossBuffs);
-        end
-        do
-            local isBossAura = false;
-            local isBossBuff = false;
-            frameNum, maxDebuffs = SetDebuffsHelper(frame.debuffFrames, frameNum, maxDebuffs, "HARMFUL", isBossAura, isBossBuff, priorityDebuffs);
-        end
-        do
-            local isBossAura = false;
-            local isBossBuff = false;
-            frameNum, maxDebuffs = SetDebuffsHelper(frame.debuffFrames, frameNum, maxDebuffs, "HARMFUL|RAID", isBossAura, isBossBuff, nonBossRaidDebuffs);
-        end
-        do
-            local isBossAura = false;
-            local isBossBuff = false;
-            frameNum, maxDebuffs = SetDebuffsHelper(frame.debuffFrames, frameNum, maxDebuffs, "HARMFUL", isBossAura, isBossBuff, nonBossDebuffs);
-        end
-        numUsedDebuffs = frameNum - 1;
+                return false;
+            end);
 
-        CompactUnitFrame_HideAllBuffs(frame, numUsedBuffs + 1);
-        CompactUnitFrame_HideAllDebuffs(frame, numUsedDebuffs + 1);
-        CompactUnitFrame_HideAllDispelDebuffs(frame, numUsedDispelDebuffs + 1);
+            CompactUnitFrame_HideAllBuffs(frame, frameNum);
+        end
+
+        if dispelsChanged then
+            local frameNum = 1;
+            local maxDispelDebuffs = frame.maxDispelDebuffs;
+            for _, auraTbl in pairs(frame.dispels) do
+                if frameNum > maxDispelDebuffs then
+                    break;
+                end
+                if auraTbl:Size() ~= 0 then
+                    local dispellDebuffFrame = frame.dispelDebuffFrames[frameNum];
+                    CompactUnitFrame_UtilSetDispelDebuff(dispellDebuffFrame, auraTbl:GetTop());
+                    frameNum = frameNum + 1;
+                end
+            end
+
+            CompactUnitFrame_HideAllDispelDebuffs(frame, frameNum);
+        end
 
         BigDebuffs:ShowBigDebuffs(frame)
     end)

--- a/BigDebuffs.toc
+++ b/BigDebuffs.toc
@@ -1,4 +1,4 @@
-## Interface: 90207
+## Interface: 100000
 ## Title: BigDebuffs
 ## Notes: Increases the debuff size of crowd control effects on the Blizzard raid frames
 ## Version: @project-version@

--- a/BigDebuffs.xml
+++ b/BigDebuffs.xml
@@ -4,11 +4,6 @@
         <Size>
             <AbsDimension x="36" y="36"/>
         </Size>
-        <Anchors>
-            <Anchors>
-                <Anchor point="CENTER"/>
-            </Anchors>
-        </Anchors>
         <NormalTexture name="$parentNormalTexture" parentKey="NormalTexture">
             <Anchors>
                 <Anchor point="TOPLEFT" x="-15" y="15"/>


### PR DESCRIPTION
Closes #421 #423 

Took a stab at support for Dragon Flight.  Definitely ran into some interesting issues with retail vs classic.
This PR is pretty close to complete, some of it is not pretty, but it works 😃 Might work on some refactor later, just wanted this working while I test classes.

2 known issues, I have not figured out how to support new Blizzard party frames, I have some code commented out that is close, but not quite there, I moved on as I assume most users don't use party frames, but rather raid style frames.  2nd issue is when you use the Test feature in the settings menu the frames are movable, not sure this is actually new or not, but noticed it while I was testing anchors on the new frames.

Last thing to note, had to update a bunch of Ace libs, no idea how that works in the package, but assuming some sort of packager figures all that out.  Anyways would mention in case there are issues.