### PR TITLE
allow anchor to be nil if frame does not exist

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -849,8 +849,8 @@ function BigDebuffs:AttachUnitFrame(unit)
                 if v.func then
                     anchor, parent, noPortait = v.func(v.units[unit])
                 else
-                    if k == "Blizzard" then
-                        anchor = type(v.units[unit]) == "string" and _G[v.units[unit]] or v.units[unit]
+                    if k == "Blizzard" and type(v.units[unit]) == "table" then
+                        anchor = v.units[unit]
                     else
                         anchor = _G[v.units[unit]]
                     end


### PR DESCRIPTION
Closes #426 

In Wrath ArenaEnemyFrame1ClassPortrait [1-5] are not loaded on login or likely anywhere outside an arena.  I did what little testing I could, but don't have an easy way to arena in Wrath.
