### PR TITLE
fix displaying 6 buffs

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1172,6 +1172,7 @@ function BigDebuffs:AddBigDebuffs(frame)
     if not frame or not frame.displayedUnit or not UnitIsPlayer(frame.displayedUnit) then return end
     local frameName = frame:GetName()
     if self.db.profile.raidFrames.increaseBuffs then
+        CompactUnitFrame_SetMaxBuffs(frame, 6)
         for i = 4, MAX_BUFFS do
             local buffPrefix = frameName .. "Buff"
             local buffFrame = _G[buffPrefix .. i] or


### PR DESCRIPTION
#425 
this fixes the displaying of 6 buffs, but causes taint to the function ClearTarget()

No idea why, but the only place I noticed that it matters is when exiting the new blizzard edit mode, the exit will not clear your target or focus and gives an error.

Figured I would submit and see if anyone knows how to fix that.