### PR TITLE
Allow using Blizzard nameplates in Threat Plates

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -530,9 +530,9 @@ local nameplatesAnchors = {
         func = GetNameplateAnchor.NeatPlates,
     },
     [6] = {
-        used = function()
+        used = function(frame)
             -- IsAddOnLoaded("TidyPlates_ThreatPlates") should be better
-            return TidyPlatesThreat ~= nil
+            return TidyPlatesThreat ~= nil and frame.TPFrame:IsShown()
         end,
         func = GetNameplateAnchor.ThreatPlates,
     },


### PR DESCRIPTION
When using the "Show Blizzard Nameplates for Neutral and Enemy Units" or "Show Blizzard Nameplates for Friendly Units" option/s in Threat Plates, BigDebuffs does not show on the nameplates. Using Blizzard nameplates when ThreatPlates does not show a nameplate fixes the problem.