### PR TITLE
Evoker support with 10.0.2

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -271,6 +271,13 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
         [581] = {
             Magic = function() return GetSpellInfo(205604) end, -- Reverse Magic
         },
+        [1467] = { -- Devastation Evoker
+            Poison = true,
+        },
+        [1468] = { -- Preservation Evoker
+            Magic = true,
+            Poison = true,
+        },
     }
 else
     local classDispel = {

--- a/BigDebuffs.toc
+++ b/BigDebuffs.toc
@@ -1,4 +1,4 @@
-## Interface: 100000
+## Interface: 100002
 ## Title: BigDebuffs
 ## Notes: Increases the debuff size of crowd control effects on the Blizzard raid frames
 ## Version: @project-version@


### PR DESCRIPTION
Only the 'default' cleanse spell is added to the list. The extra one which could remove everything (with some heal and 1 min CD) is ignored.