### PR TITLE
Fixed ElvUI anchor when no player in party frame

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -345,7 +345,6 @@ local GetAnchor = {
                     end
                 end
             end
-            return
         end
 
         if unit and (unit:match("arena") or unit:match("arena")) then


### PR DESCRIPTION
When not in a party or disabling "Display player" in ElvUI party group settings, no anchor would be found, this should fix the issue.