### PR TITLE
Potential fix for the taint issue

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -429,6 +429,27 @@ local GetAnchor = {
             return frame, frame, true
         end
     end,
+    Cell = function(anchor)
+        local anchors, unit = BigDebuffs.anchors
+
+        for u, configAnchor in pairs(anchors.Cell.units) do
+            if anchor == configAnchor then
+                unit = u
+                break
+            end
+        end
+
+        if unit and (unit:match("party") or unit:match("player")) then
+            if Cell then
+                local guid = UnitGUID(unit)
+                local frame = Cell.funcs:GetUnitButtonByGUID(guid)
+                if frame then
+                    return frame, frame, true
+                end
+            end
+            return
+        end
+    end,
 }
 
 local GetNameplateAnchor = {
@@ -530,9 +551,9 @@ local nameplatesAnchors = {
         func = GetNameplateAnchor.NeatPlates,
     },
     [6] = {
-        used = function()
+        used = function(frame)
             -- IsAddOnLoaded("TidyPlates_ThreatPlates") should be better
-            return TidyPlatesThreat ~= nil
+            return TidyPlatesThreat ~= nil and frame.TPFrame:IsShown()
         end,
         func = GetNameplateAnchor.ThreatPlates,
     },
@@ -661,6 +682,18 @@ local anchors = {
             arena3 = "sArenaEnemyFrame3",
             arena4 = "sArenaEnemyFrame4",
             arena5 = "sArenaEnemyFrame5",
+        },
+    },
+    ["Cell"] = {
+        noPortait = true,
+        alignLeft = true,
+        func = GetAnchor.Cell,
+        units = {
+            player = "CellPartyFrameMember1",
+            party1 = "CellPartyFrameMember2",
+            party2 = "CellPartyFrameMember3",
+            party3 = "CellPartyFrameMember4",
+            party4 = "CellPartyFrameMember5",
         },
     },
     ["Blizzard"] = {
@@ -1228,18 +1261,19 @@ function BigDebuffs:AddBigDebuffs(frame)
     end
     return true
 end
+
+local pending = {}
 function checkFrame(frame)
     if not issecurevariable(frame, "action") and not InCombatLockdown() then
         frame.action = nil
         frame:SetAttribute("action");
     end
 end
-local pending = {}
 
 hooksecurefunc("CompactUnitFrame_UpdateAll", function(frame)
-	for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-		hooksecurefunc(frame, "UpdateAction", checkFrame);
-	end
+   for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
+	 hooksecurefunc(frame, "UpdateAction", checkFrame);
+   end
     if not BigDebuffs.db.profile then return end
     if not BigDebuffs.db.profile.raidFrames then return end
     if not BigDebuffs.db.profile.raidFrames.enabled then return end
@@ -1275,7 +1309,7 @@ function BigDebuffs:IsPriorityDebuff(id)
     end
 end
 
-hooksecurefunc("CompactUnitFrame_HideAllDebuffs",HideBigDebuffs)
+hooksecurefunc("CompactUnitFrame_HideAllDebuffs", HideBigDebuffs)
 
 function BigDebuffs:IsDispellable(unit, dispelType)
     if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then
@@ -1390,9 +1424,9 @@ end
 
 if LibClassicDurations then
     hooksecurefunc("CompactUnitFrame_UtilSetBuff", function(buffFrame, unit, index, filter)
-		for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-			hooksecurefunc(frame, "UpdateAction", checkFrame);
-		end
+	    for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
+	  	  hooksecurefunc(frame, "UpdateAction", checkFrame);
+	    end	
         if not LibClassicDurations then return end
         local name, icon, count, debuffType, duration, expirationTime, unitCaster,
         canStealOrPurge, _, spellId, canApplyAura = UnitBuff(unit, index, filter);
@@ -1467,9 +1501,9 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
     end
 
     hooksecurefunc("CompactUnitFrame_UpdateAuras", function(frame, unitAuraUpdateInfo)
-		for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-			hooksecurefunc(frame, "UpdateAction", checkFrame);
-		end		
+        for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
+	      hooksecurefunc(frame, "UpdateAction", checkFrame);
+        end	
 
         if (not frame) or frame:IsForbidden() then return end
 
@@ -1738,9 +1772,9 @@ else
     end
 
     hooksecurefunc("CompactUnitFrame_UpdateDebuffs", function(frame)
-		for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-			hooksecurefunc(frame, "UpdateAction", checkFrame);
-		end
+	    for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
+		  hooksecurefunc(frame, "UpdateAction", checkFrame);
+	     end
         if (not frame.debuffFrames or not frame.optionTable.displayDebuffs) then
             CompactUnitFrame_HideAllDebuffs(frame);
             return;
@@ -1839,8 +1873,8 @@ else
     -- Show extra buffs
     hooksecurefunc("CompactUnitFrame_UpdateBuffs", function(frame)
 		for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-			hooksecurefunc(frame, "UpdateAction", checkFrame);
-		end
+		   hooksecurefunc(frame, "UpdateAction", checkFrame);
+		 end
         if (not frame.buffFrames or not frame.optionTable.displayBuffs) then
             CompactUnitFrame_HideAllBuffs(frame);
             return;


### PR DESCRIPTION
Got this idea from another addon that might be a fix for potential taint issues when opening the editmode. I just added this function  
function checkFrame(frame)
    if not issecurevariable(frame, "action") and not InCombatLockdown() then
        frame.action = nil
        frame:SetAttribute("action");
    end
end

and used it in every hooksecurfun call like 

  for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
	hooksecurefunc(frame, "UpdateAction", checkFrame);
  end

But this may need more testing because I think it create other issues. I use biggerbuff addon for druid to show more than 3 buffs. But it's only for showing more than 3 buffs on raid frame. Bigdebuff is more complicated so this is just a suggestion. Maybe it gives you an idea how to fix the issue.