### PR TITLE
Adding Deathmark to Rogue's Spell List

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -462,6 +462,7 @@ addon.Spells = {
     [345569] = { type = BUFF_OFFENSIVE }, -- Flagellation (Venthyr Ability)
     [347037] = { type = BUFF_OFFENSIVE }, -- Sepsis (Night Fae Ability)
     [328305] = { type = DEBUFF_OFFENSIVE, priority = true}, -- Sepsis (Night Fae Ability)
+    [360194] = { type = DEBUFF_OFFENSIVE, priority = true}, -- Deathmark
 
     -- Shaman
 


### PR DESCRIPTION
As the PR title states, just adding the missing Deathmark spell that Rogues got in Dragonflight