### PR TITLE
fix from issue #435

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -931,7 +931,7 @@ function BigDebuffs:AttachUnitFrame(unit)
             if frame.anchor.SetDrawLayer then frame.anchor:SetDrawLayer("BACKGROUND") end
             local parent = frame.anchor.portrait and frame.anchor.portrait:GetParent() or frame.anchor:GetParent()
             frame:SetParent(parent)
-            frame:SetFrameLevel(parent:GetFrameLevel())
+            frame:SetFrameLevel(parent:GetFrameLevel() + 1)
 
             if frame.anchor.portrait then
                 frame.anchor.portrait:SetDrawLayer("BACKGROUND")


### PR DESCRIPTION
ive isolated this issue using only bigdebuffs active but have been unable to reliably reproduce it, yet it does happen frequently, especially considering the need to /reload before every single arena match due to so much tainting going on with addons. not exactly sure what this fix does except perhaps adjusting the frame strata, but it seems to completely fix the issue. for the record, this only occurs with the player frame. 

pic showing the issue: https://i.imgur.com/NFV8lC7.png

the barkskin icon is behind my playerframeportrait