### PR TITLE
Revert "fix from issue #435"

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -931,7 +931,7 @@ function BigDebuffs:AttachUnitFrame(unit)
             if frame.anchor.SetDrawLayer then frame.anchor:SetDrawLayer("BACKGROUND") end
             local parent = frame.anchor.portrait and frame.anchor.portrait:GetParent() or frame.anchor:GetParent()
             frame:SetParent(parent)
-            frame:SetFrameLevel(parent:GetFrameLevel() + 1)
+            frame:SetFrameLevel(parent:GetFrameLevel())
 
             if frame.anchor.portrait then
                 frame.anchor.portrait:SetDrawLayer("BACKGROUND")


### PR DESCRIPTION
this ended up being a bad change and should be reverted. while it does fix this common issue with the player frame, it fucks up the target/focus frames by causing the bd portrait icon to have a higher level than the portrait boarder so the icon sits on top of the graphic:

https://i.imgur.com/MQn8Ojs.png

not sure what the fix is for only the player frame 