### PR TITLE
Fix action bar block

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1304,16 +1304,6 @@ function BigDebuffs:AddBigDebuffs(frame)
 end
 
 local pending = {}
-local function checkFrame(frame)
-    if not issecurevariable(frame, "action") and not InCombatLockdown() then
-        frame.action = nil
-        frame:SetAttribute("action");
-    end
-end
-
-for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
-    if frame.UpdateAction then hooksecurefunc(frame, "UpdateAction", checkFrame) end
-end
 
 hooksecurefunc("CompactUnitFrame_UpdateAll", function(frame)
 	if not BigDebuffs.db.profile then return end


### PR DESCRIPTION
After playing the game (continuous arena queues) for a while, the addon would just randomly block all my action bars.
Pressing the keybinds is completely broken while mouse click still works.

After enabling taintLog level 2, here is the possible culprit.

The first block in the taint log is:
`An action was blocked in combat because of taint from BigDebuffs - ActionButton1:SetAttribute()`

Looking back from there, the `SetAttribute` taint happens around here:
```
1/22 14:48:19.419      Interface/FrameXML/ActionButton.lua:486 OverrideActionBarButton1:UpdateSpellHighlightMark()
1/22 14:48:19.419      Interface/FrameXML/ActionButton.lua:392 OverrideActionBarButton1:Update()
1/22 14:48:19.419      Interface/FrameXML/ActionButton.lua:362
1/22 14:48:19.419      OverrideActionBarButton1:UpdateAction()
1/22 14:48:19.419      Interface/FrameXML/ActionButton.lua:354
1/22 14:48:19.419      OverrideActionBarButton1:SetAttribute()
**1/22 14:48:19.419      Interface/AddOns/BigDebuffs/BigDebuffs.lua:1321**
1/22 14:48:19.419      UpdateAction()
```

Looking at the BigDebuffs code, I see the following:
```
local function checkFrame(frame)
    if not issecurevariable(frame, "action") and not InCombatLockdown() then
        frame.action = nil
        frame:SetAttribute("action");
    end
end

for _, frame in ipairs(ActionBarButtonEventsFrame.frames) do
    if frame.UpdateAction then hooksecurefunc(frame, "UpdateAction", checkFrame) end
end
```

This piece of code was added quite recently to address some issue in editing mode, but after removing the code, I don't see any issues.
So far I haven't seen the random action bar blocks.
I don't know why we would need to interact with action bars' `UpdateAction` in the first place, but removing this seems to fix the action bar blocks.