### PR TITLE
Add deathmark to priority spells

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -40,6 +40,7 @@ addon.WarningDebuffs = {
 
 -- Make sure we always see these debuffs, but don't make them bigger
 addon.PriorityDebuffs = {
+    360194, -- Deathmark
     316099, -- Unstable Affliction
     342938, -- Unstable Affliction
     34914, -- Vampiric Touch


### PR DESCRIPTION
With the high threat of assa rogue one shot, I think we should add deathmark to the priority debuff list