### PR TITLE
Removing Blistering Scales

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -204,7 +204,6 @@ addon.Spells = {
     [374348] = { type = BUFF_DEFENSIVE }, -- Renewing Blaze
     [357170] = { type = BUFF_DEFENSIVE }, -- Time Dilation
     [406732] = { type = BUFF_DEFENSIVE }, -- Spatial Paradox
-    [360827] = { type = BUFF_DEFENSIVE }, -- Blistering Scales
     [404977] = { type = BUFF_DEFENSIVE }, -- Time Skip
     [375087] = { type = BUFF_OFFENSIVE }, -- Dragonrage
     [383005] = { type = DEBUFF_OFFENSIVE }, -- Chrono Loop


### PR DESCRIPTION
I thought it would be a short duration buff similar to Thorns so I think it's better to remove it for now. It might be useful in the BUFF_OTHER category in the future. Small change so push this whenever :)