### PR TITLE
Raid frame debuff wrapping option

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1289,19 +1289,27 @@ function BigDebuffs:AddBigDebuffs(frame)
 
     frame.BigDebuffs = frame.BigDebuffs or {}
     local max = self.db.profile.raidFrames.maxDebuffs + 1 -- add a frame for warning debuffs
+    local wrapAt = self.db.profile.raidFrames.wrapAt
     for i = 1, max do
         local big = frame.BigDebuffs[i] or
             CreateFrame("Button", frameName .. "BigDebuffsRaid" .. i, frame, "BigDebuffsDebuffTemplate")
         big:ClearAllPoints()
-        if i > 1 then
-            if self.db.profile.raidFrames.anchor == "INNER" or self.db.profile.raidFrames.anchor == "RIGHT" or
-                self.db.profile.raidFrames.anchor == "TOP" then
+        if i > 1 and i ~= wrapAt + 1 then
+            if self.db.profile.raidFrames.anchor == "INNER" or self.db.profile.raidFrames.anchor == "RIGHT" or self.db.profile.raidFrames.anchor == "TOP" then
                 big:SetPoint("BOTTOMLEFT", frame.BigDebuffs[i - 1], "BOTTOMRIGHT", 0, 0)
             elseif self.db.profile.raidFrames.anchor == "LEFT" then
                 big:SetPoint("BOTTOMRIGHT", frame.BigDebuffs[i - 1], "BOTTOMLEFT", 0, 0)
             elseif self.db.profile.raidFrames.anchor == "BOTTOM" then
                 big:SetPoint("TOPLEFT", frame.BigDebuffs[i - 1], "TOPRIGHT", 0, 0)
             end
+        elseif i == wrapAt + 1 and  wrapAt ~= 0 then
+            if self.db.profile.raidFrames.anchor == "INNER" or self.db.profile.raidFrames.anchor == "RIGHT" or self.db.profile.raidFrames.anchor == "TOP" then
+                big:SetPoint("BOTTOMLEFT", frame.BigDebuffs[1], "TOPLEFT",0, 1)
+            elseif self.db.profile.raidFrames.anchor == "LEFT" then
+                big:SetPoint("BOTTOMRIGHT", frame.BigDebuffs[1], "TOPRIGHT", 0,1)
+            elseif self.db.profile.raidFrames.anchor == "BOTTOM" then
+                big:SetPoint("TOPLEFT", frame.BigDebuffs[1], "BOTTOMLEFT", 0, -1)
+            end    
         else
             if self.db.profile.raidFrames.anchor == "INNER" then
                 big:SetPoint("BOTTOMLEFT", frame.debuffFrames[1], "BOTTOMLEFT", 0, 0)

--- a/Options.lua
+++ b/Options.lua
@@ -366,6 +366,15 @@ function BigDebuffs:SetupOptions()
                         step = 1,
                         order = 10,
                     },
+                    wrapAt = {
+                        type = "range",
+                        name = L["Wrap After"],
+                        desc = L["Begin a new row or column after this many debuffs"],
+                        min = 0,
+                        max = 10,
+                        step = 1,
+                        order = 11,
+                    },
                     anchor = {
                         name = L["Anchor"],
                         desc = L["Anchor to attach the BigDebuffs frames"],


### PR DESCRIPTION
Added the ability to wrap the debuffs after specified amount. 
The attached images show examples of all anchors with wrap set to 3 debuffs and max debuffs of 11
![bottom](https://github.com/jordonwow/bigdebuffs/assets/56225355/5f42345f-cb3c-4c53-b003-e0bdfb7f1a9e)
![inner](https://github.com/jordonwow/bigdebuffs/assets/56225355/d723d74c-04a6-4dd2-833a-cceee72d887a)
![left](https://github.com/jordonwow/bigdebuffs/assets/56225355/824fe9e2-d8c9-4a1e-8119-f1fcccde2ad1)
![right](https://github.com/jordonwow/bigdebuffs/assets/56225355/321ee76f-6582-40b9-83a4-d263c8b26eac)
![top](https://github.com/jordonwow/bigdebuffs/assets/56225355/3d855810-1c92-48bf-8aba-fee8e82d68e6)
