### PR TITLE
Add Phantom Singularity

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -587,6 +587,7 @@ addon.Spells = {
     [702] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Curse of Weakness
     [410598] = { type = DEBUFF_OFFENSIVE, nonameplates = true }, -- Soul Rip
     [417537] = { type = DEBUFF_OFFENSIVE, nonameplates = true }, -- Oblivion
+    [205179] = { type = DEBUFF_OFFENSIVE }, -- Phantom Singularity
 
     -- Warrior
 


### PR DESCRIPTION
Adds the warlock spell [Phantom Singularity](https://www.wowhead.com/spell=205179/phantom-singularity).