### PR TITLE
Add intimidating shout

### DIFF
--- a/BigDebuffs_Vanilla.lua
+++ b/BigDebuffs_Vanilla.lua
@@ -327,6 +327,8 @@ addon.Spells = {
     -- Warrior
 
     [18498] = { type = CROWD_CONTROL }, -- Improved Shield Bash
+    [5246] = { type = CROWD_CONTROL }, -- Intimidating Shout (Other targets)
+        [20511] = { type = CROWD_CONTROL, parent = 5246 }, -- (Main target)
     [20230] = { type = IMMUNITY }, -- Retaliation
     [1719] = { type = BUFF_OFFENSIVE }, -- Recklessness
     [871] = { type = BUFF_DEFENSIVE }, -- Shield Wall


### PR DESCRIPTION
The main target cowers and other targets will be feared. Adapted from your code [here](https://github.com/jordonwow/bigdebuffs/blob/cc347b0f12fd29c57271b36a9de6427e99ef560b/BigDebuffs_Mainline.lua#L606C11-L606C61).

[main target](https://www.wowhead.com/classic/spell=20511/intimidating-shout)
[other targets](https://www.wowhead.com/classic/spell=5246/intimidating-shout)