### PR TITLE
Support for latest spell ids for warning spells and weakened soul for priest

### DIFF
--- a/BigDebuffs_Wrath.lua
+++ b/BigDebuffs_Wrath.lua
@@ -30,7 +30,9 @@ addon.WarningDebuffs = {
     30108, -- Unstable Affliction
     30404, -- Unstable Affliction
     30405, -- Unstable Affliction
+    47843, -- Unstable Affliction
     34914, -- Vampiric Touch
+    48160, -- Vampiric Touch
 }
 
 -- Make sure we always see these debuffs, but don't make them bigger
@@ -155,6 +157,7 @@ addon.Spells = {
     -- Priest
 
     -- WoTLK
+    [6788] = { type = "special", nounitFrames = true }, -- Weakened Soul   
     [20711] = { type = BUFF_DEFENSIVE, },  -- Spirit of Redemption
     [47585] = { type = IMMUNITY, },  -- Dispersion
     [47788] = { type = BUFF_DEFENSIVE, },  -- Guardian Spirit


### PR DESCRIPTION
The spell ids for vampiric touch and unstable affliction are **missing** so this pull request adds them. Should fix https://github.com/jordonwow/bigdebuffs/issues/627

```
    47843, -- Unstable Affliction
    48160, -- Vampiric Touch
```

Furthermore the weakened soul debuff for priests can often disappear as it loses priority and at the moment, isn't adjustable. This should fix https://github.com/jordonwow/bigdebuffs/issues/595 and https://github.com/jordonwow/bigdebuffs/issues/619