### PR TITLE
Add Living Bomb mage debuff

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -324,6 +324,8 @@ addon.Spells = {
     [210824] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Touch of the Magi
     [12654] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Ignite
     [390612] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Frost Bomb
+    [44461] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true }, -- Living Bomb
+        [244813] = { type = DEBUFF_OFFENSIVE, nounitFrames = true, nonameplates = true, parent = 44461 }, -- Living Bomb (spread effect)
 
     -- Monk
 


### PR DESCRIPTION
Now that Living Bomb does an ungodly amount of damage, I've found it very useful to track.