### PR TITLE
Add Shackle Undead to BigDebuffs_Vanilla

### DIFF
--- a/BigDebuffs_Vanilla.lua
+++ b/BigDebuffs_Vanilla.lua
@@ -135,6 +135,9 @@ addon.Spells = {
         [15362] = { parent = 14892 },
         [15363] = { parent = 14892 },
     [6346] = { type = BUFF_DEFENSIVE }, -- Fear Ward
+    [9484] = { type = CROWD_CONTROL }, -- Shackle Undead
+        [9485] = { parent = 9484 },
+        [10955] = { parent = 9484 },
     [402004] = { type = BUFF_DEFENSIVE },  -- Pain Suppression
     [425294] = { type = BUFF_DEFENSIVE },  -- Dispersion
 


### PR DESCRIPTION
Shackle Undead is already on the TBC, Wrath, Cata, and Mainline versions of BigDebuffs and it would be helpful to have in Vanilla as well, especially for the Atal'ai Defenders fight in Season of Discovery.