### PR TITLE
Fixed an incompatibility with Threat Plates where BigDebuffs' icons here not shown

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -528,17 +528,13 @@ local GetNameplateAnchor = {
         end
     end,
     ThreatPlates = function(frame)
-        local tp_frame = frame.TPFrame
-        if tp_frame then
-            local visual = tp_frame.visual
-            -- healthbar and name are always defined, so checks are not really needed here.
-            if visual.healthbar and visual.healthbar:IsShown() then
-                return visual.healthbar, tp_frame
-            elseif visual.name and visual.name:IsShown() then
-                return visual.name, tp_frame
-            else
-                return tp_frame, tp_frame
-            end
+        if frame.TPFrame.GetAnchor then
+            return frame.TPFrame:GetAnchor()
+        elseif frame.UnitFrame:IsShown() then
+            return frame.UnitFrame, frame.UnitFrame
+        else
+            -- Fallback solution if TP was not yet updated and GetAnchor is not available.
+            return frame.TPFrame, frame.TPFrame
         end
     end,
     TidyPlates = function(frame)
@@ -597,7 +593,7 @@ local nameplatesAnchors = {
     [6] = {
         used = function(frame)
             -- IsAddOnLoaded("TidyPlates_ThreatPlates") should be better
-            return TidyPlatesThreat ~= nil and frame.TPFrame:IsShown()
+            return TidyPlatesThreat ~= nil
         end,
         func = GetNameplateAnchor.ThreatPlates,
     },


### PR DESCRIPTION
Currently, with Threat Plates v11.2.x, BigDebuffs' icons will not be shown when TellMeWhen is enabled as well. 

The basic issue is that frame.TPFrame:IsShown() in nameplateAnchors (in BigDebuffs.lua) for Threat Plates is called before Threat Plates was updated, e.g., the frame is not yet shown, after a NAME_PLATE_UNIT_ADDED event was fired. It's explained better an in more detail here: https://github.com/ascott18/TellMeWhen/issues/2064#issuecomment-1405975273.

The below solution is based on Threat Plates providing a function that returns an anchor to which BigDebuffs can link its icons. As this requires Threat Plates to also be updated to v11.2.4 (https://github.com/Backupiseasy/ThreatPlates/releases/tag/11.2.4), a fallback solution is added. (I guess the comment about the fallback could be moved up a bit (to the elseif part)). 

This should fix all incompatibilities between TP and BigDebuffs for now: https://github.com/jordonwow/bigdebuffs/issues/621, https://github.com/jordonwow/bigdebuffs/issues/615, https://github.com/jordonwow/bigdebuffs/issues/606, https://github.com/jordonwow/bigdebuffs/issues/571, https://github.com/jordonwow/bigdebuffs/issues/518, https://github.com/jordonwow/bigdebuffs/issues/107, https://github.com/jordonwow/bigdebuffs/issues/95.