### PR TITLE
Fix issue preventing BigDebuffs usage on party frames other than ElvUI

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -381,6 +381,7 @@ local GetAnchor = {
                     end
                 end
             end
+            return
         end
 
         if unit and (unit:match("arena") or unit:match("arena")) then


### PR DESCRIPTION
I noticed that even with ElvUI's Party Frames disabled, BigDebuffs wasn't appearing on other Party Frames, like Cell's. With this fix, BigDebuffs is now showing up on the Cell addon frame, and potentially on other party frames as well.