### PR TITLE
fix: add spell ID to warning debuff entry

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -2012,7 +2012,7 @@ else
                         break
                     end
                 end
-                tinsert(debuffs, { warning, size, 0, 0, true })
+                tinsert(debuffs, { warning, size, 0, 0, warningId })
             else
                 warning = nil
             end


### PR DESCRIPTION
fixes #725 

The error message mentioned in #725 triggers when mousing over a warning bigdebuff because `SetSpellByID` is expecting an integer spell ID, but is receiving a boolean (`true`)