### PR TITLE
Added creatures' Net ability for Vanilla Hardcore

### DIFF
--- a/BigDebuffs_Vanilla.lua
+++ b/BigDebuffs_Vanilla.lua
@@ -84,6 +84,7 @@ addon.Spells = {
     [23605] = { type = BUFF_OTHER }, -- Nightfall, Spell Vulnerability
     [13494] = { type = BUFF_OFFENSIVE }, -- Manual Crowd Pummeler Haste buff
     [446391] = { type = CROWD_CONTROL }, -- Torment
+    [6533] = { type = ROOT }, -- Net
 
     -- Interrupts
 


### PR DESCRIPTION
Added creatures Net ability for Vanilla Hardcore
https://www.wowhead.com/classic/spell=6533/net