### PR TITLE
fix: change gnaw spell ID

### DIFF
--- a/BigDebuffs_Cata.lua
+++ b/BigDebuffs_Cata.lua
@@ -131,7 +131,7 @@ addon.Spells = {
 
     [45524] = { type = ROOT }, -- Chains of Ice
     [47476] = { type = CROWD_CONTROL, },  -- Strangulate
-    [47481] = { type = CROWD_CONTROL, },  -- Gnaw
+    [91800] = { type = CROWD_CONTROL, },  -- Gnaw
     [47484] = { type = BUFF_DEFENSIVE, }, -- Huddle (Ghoul)
     [47528] = { type = INTERRUPT, duration = 4, },  -- Mind Freeze
     [48707] = { type = IMMUNITY_SPELL, },  -- Anti-Magic Shell


### PR DESCRIPTION
WoWHead Links:
[47481](https://www.wowhead.com/cata/spell=47481/gnaw)
[91800](https://www.wowhead.com/cata/spell=91800/gnaw)

Notice the 91800 ID has the debuff tooltip displayed on WoWHead, but the 47481 ID doesn't