### PR TITLE
TWW fix deprecated functions

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -15,6 +15,10 @@ if Masque ~= nil then
     BigDebuffs.MasqueGroup.NamePlate = Masque:Group("BigDebuffs", "NamePlate")
 end
 
+local UnitDebuff, UnitBuff = C_UnitAuras.GetDebuffDataByIndex, C_UnitAuras.GetBuffDataByIndex
+local GetSpellTexture = C_Spell.GetSpellTexture
+local GetSpellInfo = C_Spell.GetSpellInfo
+
 -- Defaults
 local defaults = {
     profile = {
@@ -176,7 +180,7 @@ local spellIdByName
 if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
     spellIdByName = {}
     for id, value in pairs(BigDebuffs.Spells) do
-        local spellName =  GetSpellInfo(id)
+        local spellName = C_Spell.GetSpellName(id)
         if spellName and (not value.parent) then spellIdByName[spellName] = id end
     end
 else
@@ -281,25 +285,25 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
         },
         [1467] = { -- Devastation Evoker
             Poison = true,
-            Disease = function() return IsUsableSpell(GetSpellInfo(374251)) end,
-            Curse = function() return IsUsableSpell(GetSpellInfo(374251)) end,
+            Disease = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
+            Curse = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
         },
         [1468] = { -- Preservation Evoker
             Magic = true,
             Poison = true,
-            Disease = function() return IsUsableSpell(GetSpellInfo(374251)) end,
-            Curse = function() return IsUsableSpell(GetSpellInfo(374251)) end,
+            Disease = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
+            Curse = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
         },
         [1473] = { -- Augmentation Evoker
             Poison = true,
-            Disease = function() return IsUsableSpell(GetSpellInfo(374251)) end,
-            Curse = function() return IsUsableSpell(GetSpellInfo(374251)) end,
+            Disease = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
+            Curse = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
         },
         [577] = {
-            Magic = function() return GetSpellInfo(205604) end, -- Reverse Magic
+            Magic = function() return C_Spell.GetSpellName(205604) end, -- Reverse Magic
         },
         [581] = {
-            Magic = function() return GetSpellInfo(205604) end, -- Reverse Magic
+            Magic = function() return C_Spell.GetSpellName(205604) end, -- Reverse Magic
         },
     }
 else
@@ -324,17 +328,17 @@ else
             Disease = true,
             Poison = true,
             -- Shamans 'Cleanse Spirit' restoration talent
-            Curse = function() return IsUsableSpell(GetSpellInfo(51886)) end
+            Curse = function() return IsUsableSpell(C_Spell.GetSpellName(51886)) end
         },
         WARLOCK = {
             -- Felhunter's Devour Magic or Doomguard's Dispel Magic
-            Magic = function() return IsUsableSpell(GetSpellInfo(19736)) or IsUsableSpell(GetSpellInfo(19476)) end,
+            Magic = function() return IsUsableSpell(C_Spell.GetSpellName(19736)) or IsUsableSpell(C_Spell.GetSpellName(19476)) end,
         },
         EVOKER = {
-            Bleed = function() return IsUsableSpell(GetSpellInfo(374251)) end,
+            Bleed = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
             Poison = true,
-            Disease = function() return IsUsableSpell(GetSpellInfo(374251)) end,
-            Curse = function() return IsUsableSpell(GetSpellInfo(374251)) end,
+            Disease = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
+            Curse = function() return IsUsableSpell(C_Spell.GetSpellName(374251)) end,
         },
     }
     if WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC then
@@ -373,8 +377,6 @@ end
 for i = 1, 40 do
     table.insert(unitsWithRaid, "raid" .. i)
 end
-
-local UnitDebuff, UnitBuff = UnitDebuff, UnitBuff
 
 local GetAnchor = {
     ElvUIFrames = function(anchor)
@@ -2196,7 +2198,6 @@ end
 
 function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)
     if not self.db.profile.nameplates.enabled then return end
-
     self:AttachNameplate(unit)
 
     local frame = self.Nameplates[unit]
@@ -2209,7 +2210,7 @@ function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)
 
     for i = 1, 40 do
         -- Check debuffs
-        local _, n, _, _, d, e, caster, _, _, id = UnitDebuff(unit, i)
+        local _, n, _, _, d, e, caster, _, _, id = AuraUtil.UnpackAuraData(UnitDebuff(unit, i))
         if id then
             if self.Spells[id] and (not tContains(self.HiddenDebuffs, id)) then
                 if LibClassicDurations then
@@ -2239,7 +2240,7 @@ function BigDebuffs:UNIT_AURA_NAMEPLATE(unit)
         if LibClassicDurations then
             _, n, _, _, d, e, caster, _, _, id = LibClassicDurations:UnitAura(unit, i, "HELPFUL")
         else
-            _, n, _, _, d, e, caster, _, _, id = UnitBuff(unit, i)
+            _, n, _, _, d, e, caster, _, _, id = AuraUtil.UnpackAuraData(UnitBuff(unit, i))
         end
         if id then
             if self.Spells[id] then

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1186,7 +1186,7 @@ end
 
 local function UnitBuffByName(unit, name)
     for i = 1, 40 do
-        local n = UnitBuff(unit, i)
+        local n = AuraUtil.UnpackAuraData(UnitBuff(unit, i))
         if n == name then return true end
     end
 end
@@ -1515,7 +1515,7 @@ if LibClassicDurations then
     hooksecurefunc("CompactUnitFrame_UtilSetBuff", function(buffFrame, unit, index, filter)
         if not LibClassicDurations then return end
         local name, icon, count, debuffType, duration, expirationTime, unitCaster,
-        canStealOrPurge, _, spellId, canApplyAura = UnitBuff(unit, index, filter);
+        canStealOrPurge, _, spellId, canApplyAura = AuraUtil.UnpackAuraData(UnitBuff(unit, index, filter));
         local durationNew, expirationTimeNew = LibClassicDurations:GetAuraDurationByUnit(unit, spellId, unitCaster)
         if duration == 0 and durationNew then
             duration = durationNew
@@ -1588,11 +1588,11 @@ else
                 -- for backwards compatibility - this functionality will be removed in a future update
                 if unit then
                     if (isBossBuff) then
-                        name, icon, count, debuffType, duration, expirationTime, unitCaster, _, _, spellId = UnitBuff(unit,
-                            index, filter);
+                        name, icon, count, debuffType, duration, expirationTime, unitCaster, _, _, spellId = AuraUtil.UnpackAuraData(UnitBuff(unit,
+                            index, filter));
                     else
-                        name, icon, count, debuffType, duration, expirationTime, unitCaster, _, _, spellId = UnitDebuff(unit
-                            , index, filter);
+                        name, icon, count, debuffType, duration, expirationTime, unitCaster, _, _, spellId = AuraUtil.UnpackAuraData(UnitDebuff(unit
+                            , index, filter));
                     end
                 else
                     return;
@@ -1649,12 +1649,12 @@ else
     local Default_CompactUnitFrame_UtilIsPriorityDebuff = CompactUnitFrame_UtilIsPriorityDebuff
 
     local function CompactUnitFrame_UtilIsPriorityDebuff(unit, index, filter)
-        local _, _, _, _, _, _, _, _, _, spellId = UnitDebuff(unit, index, filter)
+        local _, _, _, _, _, _, _, _, _, spellId = AuraUtil.UnpackAuraData(UnitDebuff(unit, index, filter))
         return BigDebuffs:IsPriorityDebuff(spellId) or Default_CompactUnitFrame_UtilIsPriorityDebuff(unit, index, filter)
     end
 
     local function CompactUnitFrame_UtilShouldDisplayBuff(unit, index, filter)
-        local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura = UnitBuff(unit, index, filter);
+        local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura = AuraUtil.UnpackAuraData(UnitBuff(unit, index, filter));
 
         local hasCustom, alwaysShowMine, showForMySpec = SpellGetVisibilityInfo(spellId,
             UnitAffectingCombat("player") and "RAID_INCOMBAT" or "RAID_OUTOFCOMBAT");
@@ -1696,7 +1696,7 @@ else
         --Show both Boss buffs & debuffs in the debuff location
         --First, we go through all the debuffs looking for any boss flagged ones.
         while (frameNum <= maxDebuffs) do
-            local debuffName = UnitDebuff(frame.displayedUnit, index, filter);
+            local debuffName = AuraUtil.UnpackAuraData(UnitDebuff(frame.displayedUnit, index, filter));
             if (debuffName) then
                 if (CompactUnitFrame_UtilIsBossAura(frame.displayedUnit, index, filter, false)) then
                     local debuffFrame = frame.debuffFrames[frameNum];
@@ -1714,7 +1714,7 @@ else
         --Then we go through all the buffs looking for any boss flagged ones.
         index = 1;
         while (frameNum <= maxDebuffs) do
-            local debuffName = UnitBuff(frame.displayedUnit, index, filter);
+            local debuffName = AuraUtil.UnpackAuraData(UnitBuff(frame.displayedUnit, index, filter));
             if (debuffName) then
                 if (CompactUnitFrame_UtilIsBossAura(frame.displayedUnit, index, filter, true)) then
                     local debuffFrame = frame.debuffFrames[frameNum];
@@ -1733,7 +1733,7 @@ else
         --Now we go through the debuffs with a priority (e.g. Weakened Soul and Forbearance)
         index = 1;
         while (frameNum <= maxDebuffs) do
-            local debuffName = UnitDebuff(frame.displayedUnit, index, filter);
+            local debuffName = AuraUtil.UnpackAuraData(UnitDebuff(frame.displayedUnit, index, filter));
             if (debuffName) then
                 if (CompactUnitFrame_UtilIsPriorityDebuff(frame.displayedUnit, index, filter)) then
                     local debuffFrame = frame.debuffFrames[frameNum];
@@ -1754,7 +1754,7 @@ else
         --Now, we display all normal debuffs.
         if (frame.optionTable.displayNonBossDebuffs) then
             while (frameNum <= maxDebuffs) do
-                local debuffName = UnitDebuff(frame.displayedUnit, index, filter);
+                local debuffName = AuraUtil.UnpackAuraData(UnitDebuff(frame.displayedUnit, index, filter));
                 if (debuffName) then
                     if (
                         CompactUnitFrame_UtilShouldDisplayDebuff(frame.displayedUnit, index, filter) and
@@ -1802,7 +1802,7 @@ else
         local frameNum = 1;
         local filter = nil;
         while (frameNum <= maxBuffs) do
-            local buffName = UnitBuff(frame.displayedUnit, index, filter);
+            local buffName = AuraUtil.UnpackAuraData(UnitBuff(frame.displayedUnit, index, filter));
             if ( buffName ) then
                 if ( CompactUnitFrame_UtilShouldDisplayBuff(frame.displayedUnit, index, filter) and not CompactUnitFrame_UtilIsBossAura(frame.displayedUnit, index, filter, true) ) then
                     local buffFrame = frame.buffFrames[frameNum];
@@ -1955,7 +1955,7 @@ else
         local warning, warningId
 
         for i = 1, 40 do
-            local _, _, _, dispelType, _, time, caster, _, _, id = UnitDebuff(frame.displayedUnit, i)
+            local _, _, _, dispelType, _, time, caster, _, _, id = AuraUtil.UnpackAuraData(UnitDebuff(frame.displayedUnit, i))
             if id then
                 local reaction = caster and UnitReaction("player", caster) or 0
                 local friendlySmokeBomb = id == 212183 and reaction > 4
@@ -2080,7 +2080,7 @@ function BigDebuffs:UNIT_AURA(unit)
 
     for i = 1, 40 do
         -- Check debuffs
-        local _, n, _, _, d, e, caster, _, _, id = UnitDebuff(unit, i)
+        local _, n, _, _, d, e, caster, _, _, id = AuraUtil.UnpackAuraData(UnitDebuff(unit, i))
         if id then
             if self.Spells[id] and (not tContains(self.HiddenDebuffs, id)) then
                 if LibClassicDurations then
@@ -2110,7 +2110,7 @@ function BigDebuffs:UNIT_AURA(unit)
         if LibClassicDurations then
             _, n, _, _, d, e, caster, _, _, id = LibClassicDurations:UnitAura(unit, i, "HELPFUL")
         else
-            _, n, _, _, d, e, caster, _, _, id = UnitBuff(unit, i)
+            _, n, _, _, d, e, caster, _, _, id = AuraUtil.UnpackAuraData(UnitBuff(unit, i))
         end
         if id then
             if self.Spells[id] then

--- a/Options.lua
+++ b/Options.lua
@@ -1,12 +1,15 @@
 local BigDebuffs = LibStub("AceAddon-3.0"):GetAddon("BigDebuffs")
 local L = LibStub("AceLocale-3.0"):GetLocale("BigDebuffs")
 local LibSharedMedia = LibStub("LibSharedMedia-3.0")
+local GetSpellInfo = C_Spell.GetSpellInfo
+local GetSpellTexture = C_Spell.GetSpellTexture
+local GetAddOnMetadata = C_AddOns.GetAddOnMetadata
 
 local WarningDebuffs = {}
 if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then
     for i = 1, #BigDebuffs.WarningDebuffs do
         local id = BigDebuffs.WarningDebuffs[i]
-        local name = GetSpellInfo(id)
+        local name = C_Spell.GetSpellName(id)
         if name then
             WarningDebuffs[name] = {
                 type = "toggle",
@@ -71,7 +74,7 @@ for spellID, spell in pairs(BigDebuffs.Spells) do
                 BigDebuffs:Refresh()
             end,
             name = function(info)
-                local name = SpellNames[spellID] or GetSpellInfo(spellID)
+                local name = SpellNames[spellID] or C_Spell.GetSpellName(spellID)
                 SpellNames[spellID] = name
                 return name
             end,


### PR DESCRIPTION
not sure if this complies with format

- replaced GetSpellInfo to use C_Spell.GetSpellName instead of C_Spell.GetSpellInfo because it looked like the usage was mostly for retrieving names
- UnitDebuff and UnitBuff now uses C_UnitAuras
- AuraUtil.UnpackAuraData as it seems this fixes debuffs/buffs not showing on nameplates (interrupts were still shown), apparently used for unpacking return values with backwards compatibility