### PR TITLE
Set the atlas only if the new frame textures are actually present - compatibility adjustment

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -2194,7 +2194,8 @@ function BigDebuffs:UNIT_AURA(unit)
                         if (container.AlternatePowerFrameTexture and container.AlternatePowerFrameTexture:GetTexture() == 4642466)
                             or (container.FrameTexture and container.FrameTexture:GetTexture() == 4642466) then
                             frame.mask:SetAtlas("UI-HUD-UnitFrame-Player-Portrait-Mask", _G.TextureKitConstants.UseAtlasSize)
-                        end                    end
+                        end
+                    end
                     frame.icon:AddMaskTexture(frame.mask)
                 end
             else

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -2188,8 +2188,13 @@ function BigDebuffs:UNIT_AURA(unit)
                     frame.mask:SetAllPoints(frame.icon)
                     frame.mask:SetTexture("Interface/CHARACTERFRAME/TempPortraitAlphaMask", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
                     if frame.unit == "player" then
-                        frame.mask:SetAtlas("UI-HUD-UnitFrame-Player-Portrait-Mask", _G.TextureKitConstants.UseAtlasSize)
-                    end
+
+                        local container = PlayerFrame.PlayerFrameContainer
+                        -- set the frame.mask atlas only if the new frame textures are actually present (4642466)
+                        if (container.AlternatePowerFrameTexture and container.AlternatePowerFrameTexture:GetTexture() == 4642466)
+                            or (container.FrameTexture and container.FrameTexture:GetTexture() == 4642466) then
+                            frame.mask:SetAtlas("UI-HUD-UnitFrame-Player-Portrait-Mask", _G.TextureKitConstants.UseAtlasSize)
+                        end                    end
                     frame.icon:AddMaskTexture(frame.mask)
                 end
             else


### PR DESCRIPTION
Is it possible to implement a change so that the UI-HUD-UnitFrame-Player-Portrait-Mask is only set when the new Blizzard PlayerFrames are actually set?  think this could enhance compatibility and help avoid faulty alignment with unit frames that do not use the new Blizzard frames like this:


![Portait-Bigdebuffs](https://github.com/user-attachments/assets/a5b0f7e8-3232-4996-a9df-d8e036a334a0)
