### PR TITLE
compatibility adjustment - old versions

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -2188,12 +2188,13 @@ function BigDebuffs:UNIT_AURA(unit)
                     frame.mask:SetAllPoints(frame.icon)
                     frame.mask:SetTexture("Interface/CHARACTERFRAME/TempPortraitAlphaMask", "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE")
                     if frame.unit == "player" then
-
-                        local container = PlayerFrame.PlayerFrameContainer
-                        -- set the frame.mask atlas only if the new frame textures are actually present (4642466)
-                        if (container.AlternatePowerFrameTexture and container.AlternatePowerFrameTexture:GetTexture() == 4642466)
-                            or (container.FrameTexture and container.FrameTexture:GetTexture() == 4642466) then
-                            frame.mask:SetAtlas("UI-HUD-UnitFrame-Player-Portrait-Mask", _G.TextureKitConstants.UseAtlasSize)
+                        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+                            local container = PlayerFrame.PlayerFrameContainer
+                            -- set the frame.mask atlas only if the new frame textures are actually present (4642466)
+                            if (container.AlternatePowerFrameTexture and container.AlternatePowerFrameTexture:GetTexture() == 4642466)
+                                or (container.FrameTexture and container.FrameTexture:GetTexture() == 4642466) then
+                                frame.mask:SetAtlas("UI-HUD-UnitFrame-Player-Portrait-Mask", _G.TextureKitConstants.UseAtlasSize)
+                            end
                         end
                     end
                     frame.icon:AddMaskTexture(frame.mask)


### PR DESCRIPTION
Follow-up pull request to #785 because I had forgotten a check for the current retail version, as the PlayerFrameContainer only exists there 😞 

We should first check if we are on retail before accessing the PlayerFrameContainer, as otherwise an error will occur on older versions like Cata or Classic.

Should also fix: https://github.com/jordonwow/bigdebuffs/issues/786#issuecomment-2341565908