### PR TITLE
Add General's Phalanx and Bulwark to mainline

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -706,4 +706,8 @@ addon.Spells = {
     [266107] = { type = DEBUFF_OFFENSIVE }, -- Thirst for Blood
     [368091] = { type = DEBUFF_OFFENSIVE }, -- Infected Bite
 
+    -- The War Within World Buffs
+    [443026] = {type = IMMUNITY}, -- General's Phalanx (The General Tier 4 Benefit)
+    [462823] = {type = IMMUNITY}, -- General's Bulwark (The General Tier 6 Benefit)
+
 }


### PR DESCRIPTION
These buffs are full immunities that can occur in the open world in Khaz Algar. These two IDs are only the short buff when the immunity is triggered, not the indefinite buff that indicates the protection is active.

After testing, it seems that aura ID 442999 is defunct, and only 443026 is used for General's Phalanx. That said, there could still be a strange case where 442999 is used, so it may need to be added later.

Otherwise, both of these have been tested in the open world.