### PR TITLE
Change Aura Mastery to only show the kick-immune effect

### DIFF
--- a/BigDebuffs_Mainline.lua
+++ b/BigDebuffs_Mainline.lua
@@ -380,7 +380,7 @@ addon.Spells = {
     [20066] = { type = CROWD_CONTROL }, -- Repentance
     [10326] = { type = CROWD_CONTROL }, -- Turn Evil
     [25771] = { type = BUFF_OTHER }, -- Forbearance
-    [31821] = { type = BUFF_DEFENSIVE }, -- Aura Mastery
+    [317929] = { type = BUFF_DEFENSIVE }, -- Aura Mastery (Concentration Aura)
     [31850] = { type = BUFF_DEFENSIVE }, -- Ardent Defender
     [31884] = { type = BUFF_OFFENSIVE }, -- Avenging Wrath
         [216331] = { type = BUFF_OFFENSIVE, parent = 31884 }, -- Avenging Crusader (Holy Talent)


### PR DESCRIPTION
Aura Mastery has different effects based on the current aura (https://www.wowhead.com/spell=31821/aura-mastery)

The effect with Concentration Aura is by far the most game-altering one: `Affected allies immune to interrupts and silences.`

Since all variants share the same icon, I propose changing Aura Mastery to _only_ display when affecting Concentration Aura.