### PR TITLE
fix deprecated LoadAddOn call

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -15,6 +15,7 @@ if Masque ~= nil then
     BigDebuffs.MasqueGroup.NamePlate = Masque:Group("BigDebuffs", "NamePlate")
 end
 
+local LoadAddOn = C_AddOns.LoadAddOn
 local UnitDebuff, UnitBuff = C_UnitAuras.GetDebuffDataByIndex, C_UnitAuras.GetBuffDataByIndex
 local GetSpellTexture = C_Spell and C_Spell.GetSpellTexture or GetSpellTexture
 local GetSpellInfo = C_Spell and C_Spell.GetSpellInfo or GetSpellInfo


### PR DESCRIPTION
LoadAddOn deprecated post build 52106, fixed to C_AddOns.LoadAddOn
will also fix it not loading in mop beta 

(btw, the missing Lib files in parent directory also causing it not to load in beta)