### PR TITLE
Fix raid frames on Midnight-era CompactUnitFrame clients (MoP Classic 5.5.4)

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1770,6 +1770,12 @@ function BigDebuffs:AddBigDebuffs(frame)
     for i = 1, max do
         local big = frame.BigDebuffs[i] or
             CreateFrame("Button", frameName .. "BigDebuffsRaid" .. i, frame, "BigDebuffsDebuffTemplate")
+        -- Draw above the native (Blizzard) debuff icons. On Midnight-era clients those
+        -- are C-rendered and can't be hidden per-frame, and they sit on a strata above
+        -- the compact frame's LOW, so a higher frame level alone isn't enough -- raise
+        -- the strata so the BigDebuff isn't obscured by the small native duplicate.
+        big:SetFrameStrata("HIGH")
+        big:SetFrameLevel(frame:GetFrameLevel() + 10)
         big:ClearAllPoints()
         if i > 1 and i ~= wrapAt + 1 then
             if self.db.profile.raidFrames.anchor == "INNER" or self.db.profile.raidFrames.anchor == "RIGHT" or self.db.profile.raidFrames.anchor == "TOP" then

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1278,6 +1278,23 @@ function BigDebuffs:Refresh()
         if frame:IsVisible() and unit and UnitExists(unit) then
             if CompactUnitFrame_UpdateAuras then
                 pcall(CompactUnitFrame_UpdateAuras, frame)
+            elseif frame.auraSize and type(CompactUnitFrame_UpdateAll) == "function" then
+                -- Midnight-era clients (MoP Classic 5.5.4, TBC Anniversary 2.5.6):
+                -- native buff icons render in C with no buffFrames array to resize,
+                -- so the only lever is frame.auraSize. The C aura layout only re-reads
+                -- it on a full CompactUnitFrame_UpdateAll, and Refresh (e.g. moving the
+                -- Buff Size slider) otherwise never pushes it.
+                --
+                -- auraSize drives BOTH native buffs and native debuffs, and forcing a
+                -- full UpdateAll re-runs the native aura layout (which fights the custom
+                -- BigDebuffs icons and causes flicker). Only push it when the buff size
+                -- actually changed, so unrelated sliders (e.g. Dispellable Roots) don't
+                -- resize native auras or churn the layout on every Refresh tick.
+                local newAuraSize = frame:GetHeight() * self.db.profile.raidFrames.buffs * 0.01
+                if math.abs((frame.auraSize or 0) - newAuraSize) > 0.01 then
+                    frame.auraSize = newAuraSize
+                    pcall(CompactUnitFrame_UpdateAll, frame)
+                end
             end
         end
         if frame and frame.BigDebuffs then self:AddBigDebuffs(frame) end

--- a/Spells/Mists.lua
+++ b/Spells/Mists.lua
@@ -303,7 +303,7 @@ addon.Spells = {
     [56626] = { type = CROWD_CONTROL }, -- Sting (wasp pet stun)
     -- MoP
     [117526] = { type = CROWD_CONTROL }, -- Binding Shot
-    [128405] = { type = ROOT }, -- Narrow Escape
+    [136634] = { type = ROOT }, -- Narrow Escape (root aura; 128405 is the talent, not the applied aura)
     [126246] = { type = CROWD_CONTROL }, -- Lullaby (Crane)
     [126355] = { type = CROWD_CONTROL }, -- Paralyzing Quill (Porcupine)
     [126423] = { type = CROWD_CONTROL }, -- Petrifying Gaze (Basilisk)


### PR DESCRIPTION
## Summary

Some modernized Classic clients ship the **Midnight-era** `CompactUnitFrame`:
raid-frame buff/debuff icons are rendered in C with no Lua `buffFrames`/`debuffFrames`
arrays, and `CompactUnitFrame_UpdateAuras`, `CompactUnitFrame_UpdateDebuffs`,
`CompactUnitFrame_UtilSetBuff` and `CompactUnitFrame_HideAllDebuffs` are all `nil`. On
these clients a few raid-frame features silently did nothing. This PR fixes them.

Everything is gated on **client capability** (not `WOW_PROJECT_ID`), so legacy and
Dragonflight-era/retail paths are unchanged. The same capability path is the one v65
(#933) already added for TBC Anniversary 2.5.6.

**Verified in-game on MoP Classic 5.5.4.** I don't have a TBC Anniversary client to
test on, but since the code keys off capabilities it should apply there too.

### 1. Buff / Debuff size sliders had no effect
`Refresh()` only re-sized auras via the (nil) `CompactUnitFrame_UpdateAuras` or the
(absent) `buffFrames` array, so the RaidFrames size sliders never reached the frame.
The only size lever on these clients is `frame.auraSize`, which Blizzard re-reads only
on a full `CompactUnitFrame_UpdateAll`. The size is now written to `frame.auraSize`
and applied with a single `UpdateAll` — but only when the value actually changed,
otherwise unrelated sliders resize native auras and the size visibly jumps.

### 2. Native debuff drawn on top of the BigDebuff
An anchored BigDebuff was obscured by the small native debuff underneath it, because
native raid debuffs sit on a strata above the compact frame's `LOW`. The BigDebuff is
now raised to `HIGH` strata (the nameplate icons already bump frame level) so it draws
on top. Native debuffs can't be hidden per-frame on these clients — `optionTable` is a
shared reference, and forcing a re-entrant `CompactUnitFrame_UpdateAll` re-enters
Blizzard's private-aura anchor and errors — so drawing the BigDebuff above the native
duplicate is the clean fix.

### 3. Narrow Escape tracked the wrong spell id (MoP)
`Spells/Mists.lua` used `128405`, the Narrow Escape *talent*, which is never applied as
an aura, so the root was never detected. Changed to the applied root aura id `136634`.

## Testing
MoP Classic 5.5.4: buff/debuff size sliders respond live, BigDebuffs render above
native debuffs, Narrow Escape is detected as a root. No Lua errors
(`/console scriptErrors 1`).