### PR TITLE
Add custom spells and per-spell category/ID overrides

### DIFF
--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -213,11 +213,16 @@ local defaults = {
             buffs_speed_boost = 10,
         },
         spells = {},
+        customSpells = {},
+        spellReplacements = {},
     }
 }
 
 BigDebuffs.WarningDebuffs = addon.WarningDebuffs or {}
 BigDebuffs.Spells = addon.Spells or {}
+-- Immutable static presets, used to detect when a user category override matches
+-- the default (BigDebuffs.Spells is rebuilt into the effective merged table).
+BigDebuffs.BaseSpells = addon.Spells or {}
 BigDebuffs.HiddenDebuffs = addon.HiddenDebuffs or {}
 local tContains = tContains
 
@@ -1174,6 +1179,72 @@ end
 
 BigDebuffs.anchors = anchors
 
+-- Rebuild the effective spell list from the static presets, the per-spell
+-- category overrides and the user defined custom spells. Called on load and
+-- whenever the user edits categories or adds/removes a custom spell.
+function BigDebuffs:BuildSpellList()
+    local base = addon.Spells or {}
+    local merged = {}
+
+    -- Static presets
+    for id, data in pairs(base) do
+        merged[id] = data
+    end
+
+    -- ID replacements: re-map a preset onto a different spell ID (used to
+    -- correct a wrong/rank-variant preset ID). The base entry is removed and
+    -- its data (category, duration, flags) is carried over to the new ID.
+    local replacements = self.db and self.db.profile.spellReplacements
+    if replacements then
+        for baseID, newID in pairs(replacements) do
+            if base[baseID] and not base[baseID].parent and newID ~= baseID and not base[newID] then
+                local eff = {}
+                for k, v in pairs(base[baseID]) do eff[k] = v end
+                eff.replacedFrom = baseID
+                merged[newID] = eff
+                merged[baseID] = nil
+            end
+        end
+    end
+
+    -- Category overrides on existing (non-child) spells, keyed by effective ID
+    local overrides = self.db and self.db.profile.spells
+    if overrides then
+        for id, ov in pairs(overrides) do
+            if ov.type and merged[id] and not merged[id].parent and not merged[id].custom then
+                local eff = {}
+                for k, v in pairs(merged[id]) do eff[k] = v end
+                eff.type = ov.type
+                merged[id] = eff
+            end
+        end
+    end
+
+    -- User defined custom spells
+    local custom = self.db and self.db.profile.customSpells
+    if custom then
+        for id, cs in pairs(custom) do
+            if cs.type then
+                local eff = { type = cs.type, custom = true }
+                if cs.duration and cs.duration > 0 then eff.duration = cs.duration end
+                merged[id] = eff
+            end
+        end
+    end
+
+    self.Spells = merged
+    BigDebuffs.Spells = merged
+
+    -- Rebuild the Classic name -> id lookup (0 spellId in the combat log)
+    if spellIdByName then
+        wipe(spellIdByName)
+        for id, value in pairs(merged) do
+            local spellName = GetSpellName(id)
+            if spellName and (not value.parent) then spellIdByName[spellName] = id end
+        end
+    end
+end
+
 function BigDebuffs:OnInitialize()
     self.db = LibStub("AceDB-3.0"):New("BigDebuffsDB", defaults, true)
 
@@ -1224,13 +1295,22 @@ function BigDebuffs:OnInitialize()
         self.db.profile.raidFrames.showAllClassBuffs = true
     end
 
-    self.db.RegisterCallback(self, "OnProfileChanged", "Refresh")
-    self.db.RegisterCallback(self, "OnProfileCopied", "Refresh")
-    self.db.RegisterCallback(self, "OnProfileReset", "Refresh")
+    self.db.RegisterCallback(self, "OnProfileChanged", "OnProfileUpdated")
+    self.db.RegisterCallback(self, "OnProfileCopied", "OnProfileUpdated")
+    self.db.RegisterCallback(self, "OnProfileReset", "OnProfileUpdated")
     self.frames = {}
     self.UnitFrames = {}
     self.Nameplates = {}
+    self:BuildSpellList()
     self:SetupOptions()
+end
+
+-- Profiles carry their own category overrides and custom spells, so rebuild
+-- the effective spell list (and the options tree) whenever the profile changes.
+function BigDebuffs:OnProfileUpdated()
+    self:BuildSpellList()
+    if self.RefreshSpellOptions then self:RefreshSpellOptions() end
+    self:Refresh()
 end
 
 local function HideBigDebuffs(frame)

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -148,3 +148,21 @@ L["Match Frame Height"] = true
 L["Match the height of the frame"] = true
 L["Wrap After"] = true
 L["Begin a new row or column after this many debuffs"] = true
+
+-- Custom spells
+L["Category"] = true
+L["Change which category this spell belongs to"] = true
+L["Custom Spells"] = true
+L["Add Custom Spell"] = true
+L["Add a spell by its ID and assign it a category. Use this to track debuffs the presets are missing."] = true
+L["Add Spell"] = true
+L["Duration"] = true
+L["Override the icon timer duration in seconds (leave empty to use the spell default)"] = true
+L["Remove Spell"] = true
+L["Remove this custom spell"] = true
+L["No custom spells added yet."] = true
+L["Please enter a number"] = true
+L["No spell exists with that ID"] = true
+L["That spell is already tracked"] = true
+L["Change the spell ID this entry tracks (enter the original ID to reset)"] = true
+L["Replaces preset"] = true

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -166,3 +166,5 @@ L["No spell exists with that ID"] = true
 L["That spell is already tracked"] = true
 L["Change the spell ID this entry tracks (enter the original ID to reset)"] = true
 L["Replaces preset"] = true
+L["Already tracked"] = true
+L["Edit its category card above instead of adding it again."] = true

--- a/Options.lua
+++ b/Options.lua
@@ -13,6 +13,256 @@ local function GetSpellName(id)
     end
 end
 
+-- A trimmed EditBox widget with no confirm ("okay") button. Stock AceGUI
+-- EditBoxes only commit their value (and trigger a full options panel
+-- rebuild) when Enter is pressed or the checkmark is clicked; anything typed
+-- but not yet confirmed is lost the moment a sibling widget (e.g. a select
+-- dropdown) triggers that rebuild. This widget instead calls the option's
+-- `set` directly on every keystroke, so the backing value is always current
+-- and no explicit confirmation step is needed.
+do
+    local AceGUI = LibStub("AceGUI-3.0")
+    local WidgetType = "BigDebuffsLiveEditBox"
+    if not AceGUI:GetWidgetVersion(WidgetType) then
+        local function Control_OnEnter(frame) frame.obj:Fire("OnEnter") end
+        local function Control_OnLeave(frame) frame.obj:Fire("OnLeave") end
+        local function EditBox_OnEscapePressed(frame) AceGUI:ClearFocus() end
+        local function EditBox_OnEnterPressed(frame)
+            local self = frame.obj
+            self:Fire("OnEnterPressed", frame:GetText())
+        end
+        local function EditBox_OnFocusGained(frame) AceGUI:SetFocus(frame.obj) end
+
+        local function EditBox_OnTextChanged(frame)
+            local self = frame.obj
+            local value = frame:GetText()
+            if tostring(value) ~= tostring(self.lasttext) then
+                self.lasttext = value
+                self:Fire("OnTextChanged", value)
+                -- Commit immediately, bypassing AceConfigDialog's Enter-only
+                -- ActivateControl path so no full panel rebuild happens
+                -- while typing (which would steal keyboard focus).
+                local user = self:GetUserDataTable()
+                local option = user and user.option
+                if option and type(option.set) == "function" then
+                    option.set(nil, value)
+                end
+            end
+        end
+
+        local methods = {
+            ["OnAcquire"] = function(self)
+                self:SetWidth(200)
+                self:SetDisabled(false)
+                self:SetLabel()
+                self:SetText()
+                self:SetMaxLetters(0)
+            end,
+            ["OnRelease"] = function(self) self:ClearFocus() end,
+            ["SetDisabled"] = function(self, disabled)
+                self.disabled = disabled
+                if disabled then
+                    self.editbox:EnableMouse(false)
+                    self.editbox:ClearFocus()
+                    self.editbox:SetTextColor(0.5, 0.5, 0.5)
+                    self.label:SetTextColor(0.5, 0.5, 0.5)
+                else
+                    self.editbox:EnableMouse(true)
+                    self.editbox:SetTextColor(1, 1, 1)
+                    self.label:SetTextColor(1, .82, 0)
+                end
+            end,
+            ["SetText"] = function(self, text)
+                self.lasttext = text or ""
+                self.editbox:SetText(text or "")
+                self.editbox:SetCursorPosition(0)
+            end,
+            ["GetText"] = function(self) return self.editbox:GetText() end,
+            ["SetLabel"] = function(self, text)
+                if text and text ~= "" then
+                    self.label:SetText(text)
+                    self.label:Show()
+                    self.editbox:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 7, -18)
+                    self:SetHeight(44)
+                    self.alignoffset = 30
+                else
+                    self.label:SetText("")
+                    self.label:Hide()
+                    self.editbox:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 7, 0)
+                    self:SetHeight(26)
+                    self.alignoffset = 12
+                end
+            end,
+            ["SetMaxLetters"] = function(self, num) self.editbox:SetMaxLetters(num or 0) end,
+            ["ClearFocus"] = function(self)
+                self.editbox:ClearFocus()
+                self.frame:SetScript("OnShow", nil)
+            end,
+            ["SetFocus"] = function(self) self.editbox:SetFocus() end,
+            ["HighlightText"] = function(self, from, to) self.editbox:HighlightText(from, to) end,
+        }
+
+        local function Constructor()
+            local num = AceGUI:GetNextWidgetNum(WidgetType)
+            local frame = CreateFrame("Frame", nil, UIParent)
+            frame:Hide()
+
+            local editbox = CreateFrame("EditBox", "AceGUI-3.0"..WidgetType..num, frame, "InputBoxTemplate")
+            editbox:SetAutoFocus(false)
+            editbox:SetFontObject(ChatFontNormal)
+            editbox:SetScript("OnEnter", Control_OnEnter)
+            editbox:SetScript("OnLeave", Control_OnLeave)
+            editbox:SetScript("OnEscapePressed", EditBox_OnEscapePressed)
+            editbox:SetScript("OnEnterPressed", EditBox_OnEnterPressed)
+            editbox:SetScript("OnTextChanged", EditBox_OnTextChanged)
+            editbox:SetScript("OnEditFocusGained", EditBox_OnFocusGained)
+            editbox:SetTextInsets(0, 0, 3, 3)
+            editbox:SetMaxLetters(256)
+            editbox:SetPoint("BOTTOMLEFT", 6, 0)
+            editbox:SetPoint("BOTTOMRIGHT")
+            editbox:SetHeight(19)
+
+            local label = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            label:SetPoint("TOPLEFT", 0, -2)
+            label:SetPoint("TOPRIGHT", 0, -2)
+            label:SetJustifyH("LEFT")
+            label:SetHeight(18)
+
+            local widget = {
+                editbox = editbox,
+                label = label,
+                frame = frame,
+                type = WidgetType,
+            }
+            for method, func in pairs(methods) do
+                widget[method] = func
+            end
+            editbox.obj = widget
+
+            return AceGUI:RegisterAsWidget(widget)
+        end
+
+        AceGUI:RegisterWidgetType(WidgetType, Constructor, 1)
+    end
+end
+
+-- A Button that reserves the same header space a labeled EditBox/Dropdown
+-- does (and shares their alignoffset), so it lines up with the input row
+-- instead of sitting higher, centred on its own shorter, label-less height.
+do
+    local AceGUI = LibStub("AceGUI-3.0")
+    local WidgetType = "BigDebuffsAlignedButton"
+    if not AceGUI:GetWidgetVersion(WidgetType) then
+        local function Button_OnClick(frame, ...)
+            AceGUI:ClearFocus()
+            PlaySound(852) -- SOUNDKIT.IG_MAINMENU_OPTION
+            frame.obj:Fire("OnClick", ...)
+        end
+        local function Control_OnEnter(frame) frame.obj:Fire("OnEnter") end
+        local function Control_OnLeave(frame) frame.obj:Fire("OnLeave") end
+
+        local methods = {
+            ["OnAcquire"] = function(self)
+                self:SetWidth(200)
+                self:SetHeight(44)
+                self:SetDisabled(false)
+                self:SetText()
+            end,
+            ["SetText"] = function(self, text) self.text:SetText(text) end,
+            ["SetDisabled"] = function(self, disabled)
+                self.disabled = disabled
+                if disabled then self.button:Disable() else self.button:Enable() end
+            end,
+        }
+
+        local function Constructor()
+            local num = AceGUI:GetNextWidgetNum(WidgetType)
+            local frame = CreateFrame("Frame", nil, UIParent)
+            frame:Hide()
+
+            local button = CreateFrame("Button", "AceGUI30"..WidgetType..num, frame, "UIPanelButtonTemplate")
+            button:EnableMouse(true)
+            button:SetScript("OnClick", Button_OnClick)
+            button:SetScript("OnEnter", Control_OnEnter)
+            button:SetScript("OnLeave", Control_OnLeave)
+            button:SetPoint("BOTTOMLEFT", 0, 0)
+            button:SetPoint("BOTTOMRIGHT", 0, 0)
+            button:SetHeight(19)
+
+            local text = button:GetFontString()
+            text:ClearAllPoints()
+            text:SetPoint("TOPLEFT", 15, -1)
+            text:SetPoint("BOTTOMRIGHT", -15, 1)
+            text:SetJustifyV("MIDDLE")
+
+            local widget = {
+                button = button,
+                text = text,
+                frame = frame,
+                alignoffset = 30, -- matches the labeled EditBox/Dropdown offset
+                type = WidgetType,
+            }
+            for method, func in pairs(methods) do
+                widget[method] = func
+            end
+            button.obj = widget
+
+            return AceGUI:RegisterAsWidget(widget)
+        end
+
+        AceGUI:RegisterWidgetType(WidgetType, Constructor, 1)
+    end
+end
+
+-- A full-width, globally named status line. Explains live (as the user types
+-- a Spell ID) why the Add Spell button is disabled - e.g. that the ID is
+-- already tracked - instead of leaving a greyed-out button with no reason.
+do
+    local AceGUI = LibStub("AceGUI-3.0")
+    local WidgetType = "BigDebuffsStatusLabel"
+    if not AceGUI:GetWidgetVersion(WidgetType) then
+        local methods = {
+            ["OnAcquire"] = function(self)
+                self:SetHeight(18)
+                self:SetText("")
+            end,
+            ["SetText"] = function(self, text) self.fontstring:SetText(text or "") end,
+            -- AceConfigDialog calls this on every render after creation, which
+            -- would otherwise reset the fontstring to its font object's default
+            -- (white) colour - reapply the warning colour each time.
+            ["SetFontObject"] = function(self, font)
+                self.fontstring:SetFontObject(font)
+                self.fontstring:SetTextColor(1, 0.5, 0.2)
+            end,
+        }
+
+        local function Constructor()
+            local num = AceGUI:GetNextWidgetNum(WidgetType)
+            local frame = CreateFrame("Frame", "AceGUI30"..WidgetType..num, UIParent)
+            frame:Hide()
+
+            local fontstring = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+            fontstring:SetPoint("TOPLEFT", 4, 0)
+            fontstring:SetPoint("TOPRIGHT", -4, 0)
+            fontstring:SetJustifyH("LEFT")
+            fontstring:SetTextColor(1, 0.5, 0.2)
+
+            local widget = {
+                fontstring = fontstring,
+                frame = frame,
+                type = WidgetType,
+            }
+            for method, func in pairs(methods) do
+                widget[method] = func
+            end
+
+            return AceGUI:RegisterAsWidget(widget)
+        end
+
+        AceGUI:RegisterWidgetType(WidgetType, Constructor, 1)
+    end
+end
+
 local WarningDebuffs = {}
 if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then
     for i = 1, #BigDebuffs.WarningDebuffs do
@@ -382,6 +632,66 @@ end
 local pendingID
 local pendingType = "cc"
 
+-- Returns nil if the pending ID can be added, or an explanatory message if
+-- not (blank field, no such spell, or already tracked - and where).
+local function GetPendingSpellIssue()
+    if not pendingID then return nil end
+    if not GetSpellName(pendingID) then
+        return L["No spell exists with that ID"]
+    end
+    local existing = BigDebuffs.Spells[pendingID]
+    if existing then
+        local catName = L[existing.type] or existing.type
+        return L["Already tracked"].." ("..catName.."). "..L["Edit its category card above instead of adding it again."]
+    end
+    return nil
+end
+
+local function IsPendingSpellValid()
+    return pendingID ~= nil and GetPendingSpellIssue() == nil
+end
+
+-- The currently rendered "Add Spell" exec option and status label (rebuilt
+-- fresh by BuildSpellOptions on every panel refresh), kept so
+-- SyncAddSpellForm can find the matching live widgets below.
+local currentAddExecOption
+local currentAddStatusOption
+
+-- The Spell ID field commits on every keystroke without forcing a panel
+-- refresh (see BigDebuffsLiveEditBox above), so the Add Spell button's
+-- disabled state and the status message - normally only re-checked on a
+-- full redraw - would go stale while typing. Update them directly on the
+-- live widgets instead.
+local function SyncAddSpellForm()
+    local issue = GetPendingSpellIssue()
+    local disabled = pendingID == nil or issue ~= nil
+    local AceGUI = LibStub("AceGUI-3.0")
+
+    if currentAddExecOption then
+        for i = 1, AceGUI:GetWidgetCount("BigDebuffsAlignedButton") do
+            local frame = _G["AceGUI30BigDebuffsAlignedButton"..i]
+            if frame and frame.obj and frame:IsVisible() then
+                local user = frame.obj:GetUserDataTable()
+                if user and user.option == currentAddExecOption then
+                    frame.obj:SetDisabled(disabled)
+                end
+            end
+        end
+    end
+
+    if currentAddStatusOption then
+        for i = 1, AceGUI:GetWidgetCount("BigDebuffsStatusLabel") do
+            local frame = _G["AceGUI30BigDebuffsStatusLabel"..i]
+            if frame and frame.obj and frame:IsVisible() then
+                local user = frame.obj:GetUserDataTable()
+                if user and user.option == currentAddStatusOption then
+                    frame.obj:SetText(issue)
+                end
+            end
+        end
+    end
+end
+
 -- Tracks whether the Custom Spells tab title is currently drawn highlighted
 -- (green) so the tab bar can be refreshed when the selection changes
 -- (see the tab colour sync below)
@@ -433,9 +743,13 @@ function BigDebuffs:BuildSpellOptions()
                     id = {
                         order = 1,
                         type = "input",
+                        dialogControl = "BigDebuffsLiveEditBox",
                         name = L["Spell ID"],
                         get = function() return pendingID and tostring(pendingID) or "" end,
-                        set = function(_, value) pendingID = tonumber(value) end,
+                        set = function(_, value)
+                            pendingID = tonumber(value)
+                            SyncAddSpellForm()
+                        end,
                         validate = function(_, value)
                             local n = tonumber(value)
                             if not n then return L["Please enter a number"] end
@@ -456,18 +770,23 @@ function BigDebuffs:BuildSpellOptions()
                     exec = {
                         order = 3,
                         type = "execute",
+                        dialogControl = "BigDebuffsAlignedButton",
                         name = L["Add Spell"],
-                        disabled = function()
-                            return not (pendingID and GetSpellName(pendingID)
-                                and not BigDebuffs.Spells[pendingID])
-                        end,
+                        disabled = function() return not IsPendingSpellValid() end,
                         func = function()
+                            if not IsPendingSpellValid() then return end
                             BigDebuffs.db.profile.customSpells[pendingID] = { type = pendingType or "cc" }
                             pendingID = nil
                             BigDebuffs:BuildSpellList()
                             BigDebuffs:RefreshSpellOptions()
                             BigDebuffs:Refresh()
                         end,
+                    },
+                    status = {
+                        order = 4,
+                        type = "description",
+                        dialogControl = "BigDebuffsStatusLabel",
+                        name = function() return GetPendingSpellIssue() or "" end,
                     },
                 },
             },
@@ -479,6 +798,8 @@ function BigDebuffs:BuildSpellOptions()
             },
         },
     }
+    currentAddExecOption = custom.args.add.args.exec
+    currentAddStatusOption = custom.args.add.args.status
 
     for spellID in pairs(BigDebuffs.db.profile.customSpells) do
         local spell = BigDebuffs.Spells[spellID]

--- a/Options.lua
+++ b/Options.lua
@@ -122,7 +122,8 @@ local function BuildSpellCard(spellID, spell, isCustom)
                         end
                         return L["Change the spell ID this entry tracks (enter the original ID to reset)"]
                     end,
-                    width = "half",
+                    width = "relative",
+                    relWidth = 0.5,
                     disabled = function()
                         if isCustom then return false end
                         local s = BigDebuffs.Spells[spellID]
@@ -170,7 +171,8 @@ local function BuildSpellCard(spellID, spell, isCustom)
                     type = "select",
                     name = L["Category"],
                     desc = L["Change which category this spell belongs to"],
-                    width = "half",
+                    width = "relative",
+                    relWidth = 0.5,
                     values = categoryValues,
                     sorting = categorySorting,
                     get = function()

--- a/Options.lua
+++ b/Options.lua
@@ -54,22 +54,33 @@ local order = {
 }
 local SpellNames = {}
 local SpellIcons = {}
-local Spells = {}
-for spellID, spell in pairs(BigDebuffs.Spells) do
-    if not spell.parent then
-        Spells[spell.type] = Spells[spell.type] or {
-            name = L[spell.type],
-            type = "group",
-            order = order[spell.type],
-            args = {},
-        }
-        local key = "spell"..spellID
+
+-- Categories offered in the category dropdown (localized), in display order
+local categorySorting = {
+    "immunities", "immunities_spells", "cc", "interrupts",
+    "buffs_defensive", "buffs_offensive", "debuffs_offensive",
+    "buffs_other", "roots", "buffs_speed_boost",
+}
+local categoryValues = {}
+for _, key in ipairs(categorySorting) do categoryValues[key] = L[key] end
+
+-- Preset spells that other spells link to as a parent (shared ranks) must not
+-- be re-mapped to a different ID, or their children would be orphaned.
+local parentIDs = {}
+for _, s in pairs(BigDebuffs.BaseSpells) do
+    if s.parent then parentIDs[s.parent] = true end
+end
+
+-- Build the options card for a single spell (preset or custom). The card is
+-- keyed by spellID and reads its effective category from BigDebuffs.Spells so
+-- category overrides and custom spells are reflected the moment they change.
+local function BuildSpellCard(spellID, spell, isCustom)
         local raidFrames = spell.type == "cc" or
             spell.type == "roots" or
             spell.type == "special" or
             spell.type == "interrupts" or
             spell.type == "debuffs_offensive"
-        Spells[spell.type].args[key] = {
+        return {
             type = "group",
             get = function(info)
                 local name = info[#info]
@@ -98,8 +109,96 @@ for spellID, spell in pairs(BigDebuffs.Spells) do
                 return spellDesc..extra
             end,
             args = {
-                visibility = {
+                spellId = {
+                    order = 0,
+                    type = "input",
+                    name = L["Spell ID"],
+                    desc = function()
+                        local s = BigDebuffs.Spells[spellID]
+                        if s and s.replacedFrom then
+                            local baseName = GetSpellName(s.replacedFrom) or "?"
+                            return L["Replaces preset"]..": "..baseName.." ("..s.replacedFrom..")"
+                                .."\n\n"..L["Change the spell ID this entry tracks (enter the original ID to reset)"]
+                        end
+                        return L["Change the spell ID this entry tracks (enter the original ID to reset)"]
+                    end,
+                    width = "half",
+                    disabled = function()
+                        if isCustom then return false end
+                        local s = BigDebuffs.Spells[spellID]
+                        local baseKey = (s and s.replacedFrom) or spellID
+                        return parentIDs[baseKey] and true or false
+                    end,
+                    get = function() return tostring(spellID) end,
+                    validate = function(_, value)
+                        local n = tonumber(value)
+                        if not n then return L["Please enter a number"] end
+                        if not GetSpellName(n) then return L["No spell exists with that ID"] end
+                        if n ~= spellID and BigDebuffs.Spells[n] then return L["That spell is already tracked"] end
+                        return true
+                    end,
+                    set = function(_, value)
+                        local newID = tonumber(value)
+                        if not newID or newID == spellID then return end
+                        local sp = BigDebuffs.db.profile.spells
+                        if isCustom then
+                            local cs = BigDebuffs.db.profile.customSpells
+                            cs[newID] = cs[spellID]
+                            cs[spellID] = nil
+                        else
+                            local s = BigDebuffs.Spells[spellID]
+                            local baseID = (s and s.replacedFrom) or spellID
+                            local repl = BigDebuffs.db.profile.spellReplacements
+                            if newID == baseID then
+                                repl[baseID] = nil
+                            else
+                                repl[baseID] = newID
+                            end
+                        end
+                        -- Move per-spell overrides to the new effective ID
+                        if sp[spellID] then
+                            sp[newID] = sp[spellID]
+                            sp[spellID] = nil
+                        end
+                        BigDebuffs:BuildSpellList()
+                        BigDebuffs:RefreshSpellOptions()
+                        BigDebuffs:Refresh()
+                    end,
+                },
+                category = {
                     order = 1,
+                    type = "select",
+                    name = L["Category"],
+                    desc = L["Change which category this spell belongs to"],
+                    width = "half",
+                    values = categoryValues,
+                    sorting = categorySorting,
+                    get = function()
+                        local s = BigDebuffs.Spells[spellID]
+                        return s and s.type
+                    end,
+                    set = function(_, value)
+                        if isCustom then
+                            local c = BigDebuffs.db.profile.customSpells
+                            c[spellID] = c[spellID] or {}
+                            c[spellID].type = value
+                        else
+                            local ov = BigDebuffs.db.profile.spells
+                            ov[spellID] = ov[spellID] or {}
+                            local base = BigDebuffs.BaseSpells[spellID]
+                            if base and base.type == value then
+                                ov[spellID].type = nil
+                            else
+                                ov[spellID].type = value
+                            end
+                        end
+                        BigDebuffs:BuildSpellList()
+                        BigDebuffs:RefreshSpellOptions()
+                        BigDebuffs:Refresh()
+                    end,
+                },
+                visibility = {
+                    order = 2,
                     type = "group",
                     name = L["Visibility"],
                     inline = true,
@@ -235,9 +334,190 @@ for spellID, spell in pairs(BigDebuffs.Spells) do
                         },
                     },
                 } or nil,
+                duration = isCustom and {
+                    order = 6,
+                    type = "input",
+                    name = L["Duration"],
+                    desc = L["Override the icon timer duration in seconds (leave empty to use the spell default)"],
+                    get = function()
+                        local c = BigDebuffs.db.profile.customSpells[spellID]
+                        return (c and c.duration) and tostring(c.duration) or ""
+                    end,
+                    set = function(_, value)
+                        local c = BigDebuffs.db.profile.customSpells[spellID]
+                        if c then
+                            local n = tonumber(value)
+                            c.duration = (n and n > 0) and n or nil
+                        end
+                        BigDebuffs:BuildSpellList()
+                        BigDebuffs:Refresh()
+                    end,
+                    validate = function(_, value)
+                        if value == "" or tonumber(value) then return true end
+                        return L["Please enter a number"]
+                    end,
+                } or nil,
+                remove = isCustom and {
+                    order = 7,
+                    type = "execute",
+                    name = L["Remove Spell"],
+                    desc = L["Remove this custom spell"],
+                    width = "full",
+                    confirm = true,
+                    func = function()
+                        BigDebuffs.db.profile.customSpells[spellID] = nil
+                        BigDebuffs.db.profile.spells[spellID] = nil
+                        BigDebuffs:BuildSpellList()
+                        BigDebuffs:RefreshSpellOptions()
+                        BigDebuffs:Refresh()
+                    end,
+                } or nil,
             },
         }
+end
+
+-- Pending values for the "add custom spell" form
+local pendingID
+local pendingType = "cc"
+
+-- Tracks whether the Custom Spells tab title is currently drawn highlighted
+-- (green) so the tab bar can be refreshed when the selection changes
+-- (see the tab colour sync below)
+local customTabHighlighted = true
+local tabSyncPending = false
+
+-- Assemble the whole Spells tab: presets grouped by their (effective) category,
+-- plus a Custom Spells page for adding, editing and removing user spells.
+function BigDebuffs:BuildSpellOptions()
+    local groups = {}
+
+    for spellID, spell in pairs(BigDebuffs.Spells) do
+        if not spell.parent and not spell.custom then
+            local t = spell.type
+            groups[t] = groups[t] or {
+                name = L[t] or t,
+                type = "group",
+                order = order[t] or 50,
+                args = {},
+            }
+            groups[t].args["spell"..spellID] = BuildSpellCard(spellID, spell, false)
+        end
     end
+
+    local custom = {
+        name = function()
+            local status = LibStub("AceConfigDialog-3.0"):GetStatusTable("BigDebuffs", { "spells" })
+            local selected = status and status.groups and status.groups.selected
+            customTabHighlighted = selected ~= "custom"
+            if customTabHighlighted then
+                return "|cff20ff20"..L["Custom Spells"].."|r"
+            end
+            return L["Custom Spells"]
+        end,
+        type = "group",
+        order = 100,
+        args = {
+            add = {
+                order = 1,
+                type = "group",
+                inline = true,
+                name = L["Add Custom Spell"],
+                args = {
+                    desc = {
+                        order = 0,
+                        type = "description",
+                        name = L["Add a spell by its ID and assign it a category. Use this to track debuffs the presets are missing."].."\n",
+                    },
+                    id = {
+                        order = 1,
+                        type = "input",
+                        name = L["Spell ID"],
+                        get = function() return pendingID and tostring(pendingID) or "" end,
+                        set = function(_, value) pendingID = tonumber(value) end,
+                        validate = function(_, value)
+                            local n = tonumber(value)
+                            if not n then return L["Please enter a number"] end
+                            if not GetSpellName(n) then return L["No spell exists with that ID"] end
+                            if BigDebuffs.Spells[n] then return L["That spell is already tracked"] end
+                            return true
+                        end,
+                    },
+                    category = {
+                        order = 2,
+                        type = "select",
+                        name = L["Category"],
+                        values = categoryValues,
+                        sorting = categorySorting,
+                        get = function() return pendingType end,
+                        set = function(_, value) pendingType = value end,
+                    },
+                    exec = {
+                        order = 3,
+                        type = "execute",
+                        name = L["Add Spell"],
+                        disabled = function()
+                            return not (pendingID and GetSpellName(pendingID)
+                                and not BigDebuffs.Spells[pendingID])
+                        end,
+                        func = function()
+                            BigDebuffs.db.profile.customSpells[pendingID] = { type = pendingType or "cc" }
+                            pendingID = nil
+                            BigDebuffs:BuildSpellList()
+                            BigDebuffs:RefreshSpellOptions()
+                            BigDebuffs:Refresh()
+                        end,
+                    },
+                },
+            },
+            noneDesc = {
+                order = 2,
+                type = "description",
+                name = L["No custom spells added yet."],
+                hidden = function() return next(BigDebuffs.db.profile.customSpells) ~= nil end,
+            },
+        },
+    }
+
+    for spellID in pairs(BigDebuffs.db.profile.customSpells) do
+        local spell = BigDebuffs.Spells[spellID]
+        if spell then
+            custom.args["custom"..spellID] = BuildSpellCard(spellID, spell, true)
+        end
+    end
+
+    groups.custom = custom
+
+    -- Keep the Custom Spells tab title highlighted while it is not the active
+    -- sub-tab. The tab bar is only rebuilt on a full panel refresh, not when a
+    -- sub-tab is clicked, so every sub-tab carries a hidden checker that requests
+    -- a refresh when the drawn colour no longer matches the current selection.
+    for key, group in pairs(groups) do
+        group.args._tabColorSync = {
+            order = -1000,
+            type = "description",
+            name = "",
+            hidden = function()
+                local shouldHighlight = key ~= "custom"
+                if customTabHighlighted ~= shouldHighlight and not tabSyncPending then
+                    tabSyncPending = true
+                    C_Timer.After(0, function()
+                        tabSyncPending = false
+                        LibStub("AceConfigRegistry-3.0"):NotifyChange("BigDebuffs")
+                    end)
+                end
+                return true
+            end,
+        }
+    end
+
+    return groups
+end
+
+-- Rebuild the Spells tab in place and refresh the open panel
+function BigDebuffs:RefreshSpellOptions()
+    if not self.options then return end
+    self.options.args.spells.args = self:BuildSpellOptions()
+    LibStub("AceConfigRegistry-3.0"):NotifyChange("BigDebuffs")
 end
 
 function BigDebuffs:SetupOptions()
@@ -1756,10 +2036,13 @@ function BigDebuffs:SetupOptions()
                 childGroups = "tab",
                 hidden = function() return WOW_PROJECT_ID == WOW_PROJECT_MAINLINE end,
                 order = 40,
-                args = Spells,
+                args = {},
             },
         }
     }
+
+    -- Populate the Spells tab (presets + custom) after the options tree exists
+    self.options.args.spells.args = self:BuildSpellOptions()
 
     if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then
         self.options.args.raidFrames.args.warning = {


### PR DESCRIPTION
## Summary

The built-in spell list can't currently be corrected or extended by users.
In practice a preset sometimes carries the wrong spell ID (e.g. a talent ID
instead of the applied aura, or the wrong rank variant), sits in the wrong
category, or a relevant aura is simply missing. Today the only options are
editing the addon's Lua or waiting for an upstream fix.

This PR adds a small user-facing layer on top of the existing presets so a
player can fix and extend the list from the options UI. It is fully opt-in and
changes nothing for existing users (all new stores default to empty).

## What's new

- **Custom Spells page** (Spells tab): add a buff/debuff by spell ID and pick a
  category. Input is validated (must be a real spell, not already tracked).
  Added spells get the same per-frame visibility / priority / size controls as
  presets, an optional duration for the icon timer, and a Remove button.
- **Category override** on every spell card: a dropdown to move a preset into a
  different category, which re-homes it to that category's priority/size group.
- **Editable Spell ID** on spell cards: re-map a preset onto a different spell
  ID (to correct a wrong/rank-variant preset). Entering the original ID resets
  it; per-spell overrides follow the new ID. Parent spells that other entries
  link to as a shared rank are locked, to avoid orphaning their children.

<img width="794" height="416" alt="image" src="https://github.com/user-attachments/assets/79c2540c-3e7f-410c-b0b6-7d43ce5288b8" />
<img width="822" height="320" alt="image" src="https://github.com/user-attachments/assets/797726fa-92b8-4983-8e68-515db6f2e675" />
<img width="820" height="373" alt="image" src="https://github.com/user-attachments/assets/e6d17570-012f-491e-874f-a5645fd45039" />
<img width="807" height="612" alt="image" src="https://github.com/user-attachments/assets/e95ba6be-191d-42d4-b5be-9cb071634a96" />

## How it works

- `BigDebuffs:BuildSpellList()` merges the static presets with the user's
  category overrides, ID replacements and custom spells into the effective
  `BigDebuffs.Spells` table. It runs on load, on every edit, and on profile
  change, and also rebuilds the Classic name→ID lookup.
- The options Spells tab is generated from the effective table (grouped by
  effective category) via `BuildSpellOptions()` / `RefreshSpellOptions()`, so
  overridden and custom spells appear and move live.
- New per-profile SavedVariables: `customSpells`, `spellReplacements`, and a
  `type` field on existing `spells[id]` entries. No migration needed — absence
  means "use the preset".

## Notes

- Scoped to the flavors that already show the Spells tab (hidden on Retail as
  before); no runtime behavior changes when the new stores are empty.
- The Custom Spells sub-tab is ordered last and its title is highlighted while
  it is not the active tab, as a hint that user content lives there.

## Testing

- Tested in-game on MoP Classic (5.5.4) with `scriptErrors 1`, no Lua errors:
  add/edit/remove custom spells, category changes, ID re-map + reset, duplicate
  and invalid-ID rejection, and profile switching. Effective enlarging on raid
  frames / unit frames / nameplates confirmed for added and re-categorized
  spells.